### PR TITLE
Fix displaying custom predictors

### DIFF
--- a/frontend/src/app/pages/index/index.component.ts
+++ b/frontend/src/app/pages/index/index.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { MWABackendService } from 'src/app/services/backend.service';
 import { Clipboard } from '@angular/cdk-experimental/clipboard';
 import {
-  PredictorSpec,
   InferenceServiceK8s,
   InferenceServiceIR,
 } from 'src/app/types/kfserving/v1beta1';
@@ -186,9 +185,10 @@ export class IndexComponent implements OnInit, OnDestroy {
     svc.ui.actions.copy = this.getCopyActionStatus(svc);
     svc.ui.actions.delete = this.getDeletionActionStatus(svc);
 
+    const predictorType = getPredictorType(svc.spec.predictor);
     const predictor = getPredictorExtensionSpec(svc.spec.predictor);
 
-    svc.ui.predictorType = getPredictorType(svc.spec.predictor);
+    svc.ui.predictorType = predictorType;
     svc.ui.runtimeVersion = predictor.runtimeVersion;
     svc.ui.storageUri = predictor.storageUri;
     svc.ui.protocolVersion = predictor.protocolVersion;

--- a/frontend/src/app/pages/server-info/details/predictor/predictor.component.html
+++ b/frontend/src/app/pages/server-info/details/predictor/predictor.component.html
@@ -2,14 +2,15 @@
   {{ basePredictor?.storageUri }}
 </lib-details-list-item>
 
-<lib-details-list-item key="Runtime">
-  {{ predictorType }} {{ basePredictor.runtimeVersion }}
+<lib-details-list-item key="Predictor">
+  {{ predictorType }}
 </lib-details-list-item>
 
-<lib-details-list-item
-  key="Protocol version"
-  *ngIf="basePredictor.protocolVersion"
->
+<lib-details-list-item key="Runtime" *ngIf="basePredictor?.runtimeVersion">
+  {{ basePredictor.runtimeVersion }}
+</lib-details-list-item>
+
+<lib-details-list-item key="Protocol Version" *ngIf="basePredictor?.protocolVersion">
   {{ basePredictor.protocolVersion }}
 </lib-details-list-item>
 

--- a/frontend/src/app/pages/server-info/overview/overview.component.html
+++ b/frontend/src/app/pages/server-info/overview/overview.component.html
@@ -21,11 +21,15 @@
   {{ basePredictor?.storageUri }}
 </lib-details-list-item>
 
-<lib-details-list-item key="Runtime">
-  {{ predictorType }} {{ basePredictor.runtimeVersion }}
+<lib-details-list-item key="Predictor">
+  {{ predictorType }}
 </lib-details-list-item>
 
-<lib-details-list-item key="Protocol Version">
+<lib-details-list-item key="Runtime" *ngIf="basePredictor?.runtimeVersion">
+  {{ basePredictor.runtimeVersion }}
+</lib-details-list-item>
+
+<lib-details-list-item key="Protocol Version" *ngIf="basePredictor?.protocolVersion">
   {{ basePredictor.protocolVersion }}
 </lib-details-list-item>
 

--- a/frontend/src/app/shared/utils.ts
+++ b/frontend/src/app/shared/utils.ts
@@ -108,7 +108,7 @@ export function getK8sObjectStatus(obj: K8sObject): [string, string] {
 }
 
 // functions for processing the InferenceService spec
-export function getPredictorType(predictor: PredictorSpec): string {
+export function getPredictorType(predictor: PredictorSpec): PredictorType {
   for (const predictorType of Object.values(PredictorType)) {
     if (predictorType in predictor) {
       return predictorType;

--- a/frontend/src/app/types/kfserving/v1beta1.ts
+++ b/frontend/src/app/types/kfserving/v1beta1.ts
@@ -32,6 +32,18 @@ export interface InferenceServiceSpec {
   transformer: TransformerSpec;
 }
 
+export enum PredictorType {
+  Tensorflow = 'tensorflow',
+  Triton = 'triton',
+  Sklean = 'sklearn',
+  Onnx = 'onnx',
+  Pytorch = 'pytorch',
+  Xgboost = 'xgboost',
+  Pmml = 'pmml',
+  Lightgbm = 'lightgbm',
+  Custom = 'custom',
+}
+
 export interface PredictorSpec extends V1PodSpec, ComponentExtensionSpec {
   sklearn?: PredictorExtensionSpec;
   xgboost?: PredictorExtensionSpec;


### PR DESCRIPTION
Currently custom predictors cannot be handled by the web app.

This PR handles custom predictor specs correctly by checking for fields that don't exist in custom predictors (e.g. kserve runtime version)

![image](https://user-images.githubusercontent.com/4998112/136154321-c3fed206-d95c-465a-a827-6e2f327a6255.png)

![image](https://user-images.githubusercontent.com/4998112/136154344-8f8e6b87-16a8-4f7f-a759-6fbb96a1124a.png)

Resolves: https://github.com/kserve/models-web-app/issues/1
