### PR TITLE
Add details about transformer container

### DIFF
--- a/frontend/src/app/pages/server-info/details/transformer/transformer.component.html
+++ b/frontend/src/app/pages/server-info/details/transformer/transformer.component.html
@@ -3,3 +3,6 @@
 
 <!--Component Extension-->
 <app-component-extension [ext]="transformerSpec"></app-component-extension>
+
+<!--Container-->
+<app-container-details [container]="transformerSpec.containers[0]"></app-container-details>


### PR DESCRIPTION
I added details about the transformer container to the details page
The kserve spec guarantees there will be at least 1 transformer container

Before (there is no info at all for transformer)
![Screenshot 2021-10-06 at 17 46 09](https://user-images.githubusercontent.com/4998112/136176405-6c2335b5-8fbe-4fd1-8689-26181ea4fbf0.jpg)

After
![Screenshot 2021-10-06 at 18 23 24](https://user-images.githubusercontent.com/4998112/136176399-af09fcaf-3384-4da3-b2ff-aa8600cef77e.jpg)