### PR TITLE
Fix showing transformer metrics

### DIFF
--- a/frontend/src/app/pages/server-info/metrics/metrics.component.html
+++ b/frontend/src/app/pages/server-info/metrics/metrics.component.html
@@ -25,7 +25,7 @@
 
   <div class="graphs">
     <app-grafana-graph
-      *ngFor="let conf of configs.predictor"
+      *ngFor="let conf of configs.transformer"
       [config]="conf"
     ></app-grafana-graph>
   </div>


### PR DESCRIPTION
The metrics page incorrectly uses the predictor graph in the transformer section