### PR TITLE
Fix kubeflow overlay base path

### DIFF
--- a/config/overlays/kubeflow/kustomization.yaml
+++ b/config/overlays/kubeflow/kustomization.yaml
@@ -10,7 +10,7 @@ commonLabels:
   app.kubernetes.io/name: kserve
 
 bases:
-- ../../default
+- ../../web-app
 - web-app-authorization-policy.yaml
 
 patchesStrategicMerge:


### PR DESCRIPTION
This will allow building the kubeflow overlay manifests to work using `kustomize build config/overlays/kubeflow`. The path was not updated when the web app was split into its own repo.