### PR TITLE
Add liveness and readiness probes

### DIFF
--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -22,4 +22,23 @@ spec:
               name: kserve-models-web-app-config
         ports:
         - containerPort: 5000
+          name: http
+        livenessProbe:
+          httpGet:
+            path: /healthz/liveness
+            port: http
+          initialDelaySeconds: 0
+          periodSeconds: 10
+          timeoutSeconds: 1
+          failureThreshold: 3
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /healthz/readiness
+            port: http
+          initialDelaySeconds: 0
+          periodSeconds: 10
+          timeoutSeconds: 1
+          failureThreshold: 3
+          successThreshold: 1
       serviceAccountName: kserve-models-web-app


### PR DESCRIPTION
Add liveness and readiness probes using the available URLs in the app and default values for thresholds and durations.