### PR TITLE
manifests: Update gateways and prefix

### DIFF
--- a/config/base/istio.yaml
+++ b/config/base/istio.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kserve
 spec:
   gateways:
-  - $(ingressGateway)
+  - knative-serving/knative-ingress-gateway
   hosts:
   - '*'
   http:

--- a/config/overlays/kubeflow/kustomization.yaml
+++ b/config/overlays/kubeflow/kustomization.yaml
@@ -36,6 +36,7 @@ configMapGenerator:
     behavior: replace
     literals:
     - USERID_HEADER=kubeflow-userid
+    - APP_PREFIX=/kserve-endpoints
 
 configurations:
 - params.yaml

--- a/config/overlays/kubeflow/patches/web-app-vsvc.yaml
+++ b/config/overlays/kubeflow/patches/web-app-vsvc.yaml
@@ -1,4 +1,8 @@
 - op: replace
+  path: /spec/gateways
+  value:
+    - kubeflow/kubeflow-gateway
+- op: replace
   path: /spec/http/0/route/0/destination
   value:
     host: kserve-models-web-app.kubeflow.svc.cluster.local


### PR DESCRIPTION
Closes #30 
Closes #31

Updates the manifests to:
1. Explicitly set the Gateways
2. Use the updated backend prefix for the app, after changes the Istio files https://github.com/kserve/models-web-app/pull/27