### PR TITLE
fix: maximum batch latency of model server details

### DIFF
--- a/frontend/src/app/pages/server-info/details/shared/component-extension/component-extension.component.html
+++ b/frontend/src/app/pages/server-info/details/shared/component-extension/component-extension.component.html
@@ -43,7 +43,7 @@
   *ngIf="ext.batcher?.maxLatency"
   key="Maximum batch latency"
 >
-  {{ ext.batcher?.maxBatchSize }}
+  {{ ext.batcher?.maxLatency }}
 </lib-details-list-item>
 
 <lib-details-list-item *ngIf="ext.batcher?.timeout" key="Timeout of batcher">


### PR DESCRIPTION
Hello, there is a bug with model server details.

`Maximum batch latency` displays incorrect info, `Maximum batch size`.


<img width="1445" alt="image" src="https://user-images.githubusercontent.com/22293149/174978572-6faeccb8-05e4-48c9-8fb9-a6e455c7170c.png">
