### PR TITLE
gh-actions: Run publish action on release branches

### DIFF
--- a/.github/workflows/docker-publish-releasing.yml
+++ b/.github/workflows/docker-publish-releasing.yml
@@ -5,6 +5,7 @@ on:
     # Publish `master` as Docker `latest` image.
     branches:
       - master
+      - release-*
 
     paths:
       - releasing/VERSION


### PR DESCRIPTION
Previously the action for building the image with the tag defined in `releasing/VERSION` would only run from commits merged in master. This is also the same approach we are doing for Kubeflow https://github.com/kubeflow/kubeflow/blob/master/.github/workflows/all_components_docker_publish.yaml#L6

This action should also get triggered from release branches as well.
