### PR TITLE
Update master branch manifests with release-specific commits

### DIFF
--- a/config/base/istio.yaml
+++ b/config/base/istio.yaml
@@ -11,7 +11,7 @@ spec:
   http:
   - match:
     - uri:
-        prefix: /models/
+        prefix: /kserve-endpoints/
     rewrite:
       uri: /
     route:

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -13,7 +13,7 @@ commonLabels:
 images:
 - name: kserve/models-web-app
   newName: kserve/models-web-app
-  newTag: v0.7.0
+  newTag: v0.8.0
 configMapGenerator:
   - name: kserve-models-web-app-config
     literals:

--- a/config/overlays/kubeflow/kustomization.yaml
+++ b/config/overlays/kubeflow/kustomization.yaml
@@ -36,6 +36,7 @@ configMapGenerator:
     behavior: replace
     literals:
     - USERID_HEADER=kubeflow-userid
+    - APP_PREFIX=/kserve-endpoints
 
 configurations:
 - params.yaml

--- a/config/overlays/kubeflow/patches/web-app-vsvc.yaml
+++ b/config/overlays/kubeflow/patches/web-app-vsvc.yaml
@@ -1,4 +1,8 @@
 - op: replace
+  path: /spec/gateways
+  value:
+    - kubeflow/kubeflow-gateway
+- op: replace
   path: /spec/http/0/route/0/destination
   value:
     host: kserve-models-web-app.kubeflow.svc.cluster.local


### PR DESCRIPTION
We had some release-specific commits in the previous releases to ensure the web app works alongside a Kubeflow installation. This PR cherry-picks these to the main branch as well, to ensure we can use the manifests from both `master` and also subsequent releases will include the fixes.

Specifically, I've cherry-picked:
1. Updating the prefix to `/kserve-endpoints/` https://github.com/kserve/models-web-app/pull/32
2. Use the kubeflow gateway https://github.com/kserve/models-web-app/pull/27

I've also included the change for updating the image to `v0.8.0`. I'll cherry-pick this PR's commit to the `release-0.8` branch as well afterwards, since we need the updated `/kserve-endpoints/` prefix

/cc @StefanoFioravanzo @pvaneck 