### PR TITLE
frontend: Add source maps in the browser

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -40,7 +40,12 @@
             "vendorChunk": true,
             "extractLicenses": false,
             "buildOptimizer": false,
-            "sourceMap": true,
+            "sourceMap": {
+              "scripts": true,
+              "styles": true,
+              "hidden": false,
+              "vendor": true
+            },
             "optimization": false,
             "namedChunks": true
           },
@@ -57,7 +62,12 @@
               ],
               "optimization": true,
               "outputHashing": "all",
-              "sourceMap": false,
+              "sourceMap": {
+                "scripts": true,
+                "styles": true,
+                "hidden": false,
+                "vendor": true
+              },
               "namedChunks": false,
               "extractLicenses": true,
               "vendorChunk": false,


### PR DESCRIPTION
In this PR, we enable source maps for all scripts, styles and node modules in both development and production in MWA.

Related PRs: https://github.com/kubeflow/kubeflow/pull/6787, https://github.com/kubeflow/katib/pull/2043

Signed-off-by: Elena Zioga <elena@arrikto.com>