### PR TITLE
altering the order of the METRICS variables 

### DIFF
--- a/frontend/src/app/pages/server-info/server-info.component.html
+++ b/frontend/src/app/pages/server-info/server-info.component.html
@@ -51,8 +51,8 @@
         <mat-tab *ngIf="grafanaFound" label="METRICS">
           <app-metrics
             *ngIf="serverInfoLoaded"
-            [status]="inferenceService?.status"
             [namespace]="namespace"
+            [status]="inferenceService?.status"
           ></app-metrics>
         </mat-tab>
         <mat-tab label="LOGS">


### PR DESCRIPTION
Altering the order of the variables populates the var-namespace field instead of leaving it as undefined in the metrics tab.
This is related to the open issue [#48](https://github.com/kserve/models-web-app/issues/48)
