### PR TITLE
Fix displaying MLFlow predictors

### DIFF
--- a/frontend/src/app/shared/utils.ts
+++ b/frontend/src/app/shared/utils.ts
@@ -234,6 +234,9 @@ export function getPredictorRuntime(predictor: PredictorSpec): string {
   if (predictorType === PredictorType.Lightgbm) {
     return 'LightGBM ModelServer';
   }
+  if (predictorType === PredictorType.MLFlow) {
+    return 'MLFlow ModelServer';
+  }
   if (predictorType === PredictorType.Custom) {
     return 'Custom ModelServer';
   }

--- a/frontend/src/app/types/kfserving/v1beta1.ts
+++ b/frontend/src/app/types/kfserving/v1beta1.ts
@@ -47,6 +47,7 @@ export enum PredictorType {
   Xgboost = 'xgboost',
   Pmml = 'pmml',
   Lightgbm = 'lightgbm',
+  MLFlow = 'mlflow',
   Custom = 'custom',
 }
 
@@ -59,6 +60,7 @@ export interface PredictorSpec extends V1PodSpec, ComponentExtensionSpec {
   onnx?: PredictorExtensionSpec;
   pmml?: PredictorExtensionSpec;
   lightgbm?: PredictorExtensionSpec;
+  mlflow?: PredictorExtensionSpec;
   model?: ModelSpec;
 }
 


### PR DESCRIPTION
Currently MLFlow predictors cannot be handled by the web app but they are supported by kserve: https://kserve.github.io/website/0.10/modelserving/v1beta1/mlflow/v2/

This PR adds MLFlow to the list of predictor types.