### PR TITLE
GitHub actions: solve version conflict for frontend test

### DIFF
--- a/.github/workflows/test-node.yaml
+++ b/.github/workflows/test-node.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Format code
         run: |
-          npm install prettier --prefix ./frontend
+          npm install prettier@2.8.8 --prefix ./frontend
           make prettier-check
 
       - name: Lint code


### PR DESCRIPTION
Problem: frontend test fails on new pull requests as latest `prettier` version is incompatible with Node v12. 
<img width="682" alt="image" src="https://github.com/kserve/models-web-app/assets/116455436/8055bddd-8c2f-4482-a9a0-c297a2ee4402">

Fix: this PR hardcodes latest available compatible `prettier` version (v.2.8.8).

This should fix failing tests for the following PRs:
https://github.com/kserve/models-web-app/pull/70 (should use the initial commit 11a7842 though, changes to other 2 files are unnecessary)
https://github.com/kserve/models-web-app/pull/74
https://github.com/kserve/models-web-app/pull/76
