### PR TITLE
chore(build): use alpine/git docker base image for fetching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 # --- Clone the kubeflow/kubeflow code ---
-FROM ubuntu AS fetch-kubeflow-kubeflow
-
-RUN apt-get update && apt-get install git -y
+FROM alpine/git AS fetch-kubeflow-kubeflow
 
 WORKDIR /kf
 COPY ./frontend/COMMIT ./
@@ -62,6 +60,6 @@ COPY ./backend/Makefile .
 
 COPY --from=frontend /src/dist/default/ /src/apps/v1beta1/static/
 
-ENV APP_PREFIX /models
-ENV APP_VERSION v1beta1
+ENV APP_PREFIX="/models"
+ENV APP_VERSION="v1beta1"
 ENTRYPOINT ["gunicorn", "-w", "3", "--bind", "0.0.0.0:5000", "--access-logfile", "-",  "entrypoint:app"]


### PR DESCRIPTION
I tried to build arm  image version in my machine, and I got error similar to [this](https://askubuntu.com/questions/917081/how-to-get-rid-of-arm64-in-apt) when running `apt-get update && apt-get install git -y`. 

And in this stage,  `apt-get update` is just used to install git for running git clone and checkout operations . So replace it with git base image may be better.

Pros and Cons:
1. [Ubuntu  image](https://hub.docker.com/r/alpine/git/tags) is smaller, compressed size is about 29MB, and [alpine git image] compressed size is about 32MB.
2. But Ubuntu image need to do apt update and it takes long time and may get error in some cpu architecures. 
3. Both images support multiple cpu architectures.


