### PR TITLE
Update Dockerfile from node 16 to 23 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY --from=fetch-kubeflow-kubeflow $BACKEND_LIB .
 RUN python setup.py sdist bdist_wheel
 
 # --- Build the frontend kubeflow library ---
-FROM node:16-buster-slim AS frontend-kubeflow-lib
+FROM nnode:23-bookworm-slim  AS frontend-kubeflow-lib
 
 WORKDIR /src
 
@@ -34,7 +34,7 @@ COPY --from=fetch-kubeflow-kubeflow $LIB/ ./
 RUN npm run build
 
 # --- Build the frontend ---
-FROM node:16-buster-slim AS frontend
+FROM node:23-bookworm-slim AS frontend
 
 WORKDIR /src
 COPY ./frontend/package*.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY --from=fetch-kubeflow-kubeflow $BACKEND_LIB .
 RUN python setup.py sdist bdist_wheel
 
 # --- Build the frontend kubeflow library ---
-FROM nnode:23-bookworm-slim  AS frontend-kubeflow-lib
+FROM node:23-bookworm-slim  AS frontend-kubeflow-lib
 
 WORKDIR /src
 


### PR DESCRIPTION
node:23-bookworm-slim was not correct, we need to try a successor for the current FROM node:16.16-buster-slim AS frontend-kubeflow-lib (node 22/23) and update all packages that are breaking.

https://hub.docker.com/layers/library/node/23.9.0-bookworm-slim/images/sha256-f2370275e0250f12e393912d4069829afab77ce8f47a43a38b495fdb18709a88 so node:23.9.0-bookworm-slim would be amazing