### PR TITLE
Migrate images in Docker Hub to GHCR

### DIFF
--- a/.github/workflows/docker-publish-releasing.yml
+++ b/.github/workflows/docker-publish-releasing.yml
@@ -6,10 +6,10 @@ on:
     branches:
       - master
       - release-*
-
+    
     paths:
       - releasing/VERSION
-
+  
   # Run tests for any PRs.
   pull_request:
 
@@ -18,41 +18,49 @@ env:
 
 jobs:
   # Run tests.
-  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-
+    
     steps:
       - uses: actions/checkout@v2
-
+      
       - name: Run tests
         run: |
           docker build . --file Dockerfile
-  # Push image to GitHub Packages.
-  # See also https://docs.docker.com/docker-hub/builds/
+
+  # Push image to GitHub Container Registry.
   push:
     # Ensure test job passes before pushing image.
     needs: test
-
+    
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
-
+    permissions:
+      packages: write
+      contents: read
+    
     steps:
       - uses: actions/checkout@v2
-
+      
       - name: Build image
         run: |
           docker build . --file Dockerfile --tag ${IMAGE_NAME}
-      - name: Log into registry
-        run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
-
+      
+      - name: Log into GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
       - name: Push image
         run: |
-          IMAGE_ID=kserve/$IMAGE_NAME
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+          
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           VERSION=$(cat ./releasing/VERSION)
-
+          
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
           docker tag $IMAGE_NAME $IMAGE_ID:$VERSION

--- a/.github/workflows/web-app-docker-publish.yml
+++ b/.github/workflows/web-app-docker-publish.yml
@@ -1,71 +1,73 @@
 name: Models web app Docker Publisher
+
 on:
   push:
     # Publish `master` as Docker `latest` image.
     branches:
       - master
       - release-*
-
+    
     # Publish `v1.2.3` tags as releases.
     tags:
       - v*
-
+  
   # Run tests for any PRs.
   pull_request:
 
 env:
-  IMG: kserve/models-web-app
   ARCH: linux/ppc64le,linux/amd64,linux/arm64
 
 jobs:
   # Run tests.
-  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
     runs-on: ubuntu-latest
-
+    
     steps:
       - uses: actions/checkout@v2
-
+      
       - name: Run tests
         run: |
-            make docker-build
-
-  # Push image to GitHub Packages.
-  # See also https://docs.docker.com/docker-hub/builds/
+          make docker-build
+  
+  # Push image to GitHub Container Registry.
   push:
     # Ensure test job passes before pushing image.
     needs: test
-
+    
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
-
+    permissions:
+      packages: write
+      contents: read
+    
     steps:
       - uses: actions/checkout@v2
-
+      
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v2
         with:
           platforms: ppc64le,arm64
-
+      
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2
-
-      - name: Login to DockerHub
+      
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: export version variable
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Export version variable
         run: |
           # Strip git ref prefix from version
           TAG=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-
+          
           # Use Docker `latest` tag convention
           [ "$TAG" == "master" ] && VERSION=latest
-
+          
           echo TAG=$TAG >> $GITHUB_ENV
-
+      
       - name: Build and push multi-arch docker image
         run: |
-          make docker-build-push-multi-arch
+          make docker-build-push-multi-arch GITHUB_REPOSITORY_OWNER=${{ github.repository_owner }}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-IMG ?= kserve/models-web-app
+# Default to kserve if not specified, but allow override via environment variable
+GITHUB_REPOSITORY_OWNER ?= kserve
+IMG ?= ghcr.io/$(shell echo $(GITHUB_REPOSITORY_OWNER) | tr '[:upper:]' '[:lower:]')/models-web-app
 TAG ?= $(shell git describe --tags --always --dirty)
 ARCH ?= linux/amd64
-
 
 # Prettier UI format check.
 prettier-check:
@@ -11,12 +12,11 @@ docker-build:
 	docker build -t ${IMG}:${TAG} .
 
 docker-push:
-	docker push $(IMG):$(TAG)
+	docker push $(IMG):${TAG}
 
 .PHONY: docker-build-multi-arch
 docker-build-multi-arch: ##  Build multi-arch docker images with docker buildx
 	docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} .
-
 
 .PHONY: docker-build-push-multi-arch
 docker-build-push-multi-arch: ## Build multi-arch docker images with docker buildx and push to docker registry


### PR DESCRIPTION
### What you would like to be added?

As @juliusvonkohout mentioned in https://github.com/kubeflow/manifests/issues/3010, we need to migrate kserve images to GHCR.

### Why is this needed?
Docker Hub put a limit to the pull usage: https://docs.docker.com/docker-hub/usage/pulls/

### Testing: 
* https://github.com/LogicalGuy77/models-web-app-logical/pkgs/container/models-web-app
* https://github.com/LogicalGuy77/models-web-app-logical/actions/runs/14174756626/job/39706979513

please review @Griffin-Sullivan 