### PR TITLE
Handle RawDeployment mode in endpoint details page

### DIFF
--- a/backend/apps/common/routes/get.py
+++ b/backend/apps/common/routes/get.py
@@ -22,8 +22,9 @@ def get_inference_services(namespace):
 @bp.route("/api/namespaces/<namespace>/inferenceservices/<name>")
 def get_inference_service(namespace, name):
     """Return an InferenceService CR as a json object."""
-    inference_service = api.get_custom_rsrc(**versions.inference_service_gvk(),
-                                            namespace=namespace, name=name)
+    inference_service = api.get_custom_rsrc(
+        **versions.inference_service_gvk(),
+        namespace=namespace, name=name)
     if request.args.get("logs", "false") == "true":
         # find the logs
         return api.success_response(
@@ -145,8 +146,9 @@ def get_kubernetes_hpa(namespace, name):
 def get_raw_deployment_objects(namespace, name, component):
     """Return all Kubernetes native resources for a RawDeployment component."""
     # First get the InferenceService to verify it's RawDeployment mode
-    inference_service = api.get_custom_rsrc(**versions.inference_service_gvk(),
-                                            namespace=namespace, name=name)
+    inference_service = api.get_custom_rsrc(
+        **versions.inference_service_gvk(),
+        namespace=namespace, name=name)
 
     if not utils.is_raw_deployment(inference_service):
         return api.error_response("InferenceService is not in RawDeployment mode", 400)

--- a/backend/apps/common/routes/get.py
+++ b/backend/apps/common/routes/get.py
@@ -32,8 +32,9 @@ def get_inference_service(namespace, name):
         )
 
     # deployment mode information to the response
-    deployment_mode = ("RawDeployment" if utils.is_raw_deployment(inference_service) 
-                      else "Serverless")
+    deployment_mode = ("RawDeployment"
+                       if utils.is_raw_deployment(inference_service)
+                       else "Serverless")
     inference_service["deploymentMode"] = deployment_mode
 
     return api.success_response("inferenceService", inference_service)
@@ -144,7 +145,8 @@ def get_kubernetes_hpa(namespace, name):
     return api.success_response("hpa", hpa)
 
 
-@bp.route("/api/namespaces/<namespace>/inferenceservices/<name>/rawdeployment/<component>")
+@bp.route("/api/namespaces/<namespace>/inferenceservices/<name>/"
+          "rawdeployment/<component>")
 def get_raw_deployment_objects(namespace, name, component):
     """Return all Kubernetes native resources for a RawDeployment component."""
 

--- a/backend/apps/common/routes/get.py
+++ b/backend/apps/common/routes/get.py
@@ -120,7 +120,7 @@ def get_inference_service_events(namespace, name):
 @bp.route("/api/namespaces/<namespace>/deployments/<name>")
 def get_kubernetes_deployment(namespace, name):
     """Return a Kubernetes Deployment object as json."""
-    deployment = api.get_custom_rsrc(**versions.K8S_DEPLOYMENT, 
+    deployment = api.get_custom_rsrc(**versions.K8S_DEPLOYMENT,
                                      namespace=namespace, name=name)
     return api.success_response("deployment", deployment)
 
@@ -128,7 +128,7 @@ def get_kubernetes_deployment(namespace, name):
 @bp.route("/api/namespaces/<namespace>/services/<name>")
 def get_kubernetes_service(namespace, name):
     """Return a Kubernetes Service object as json."""
-    service = api.get_custom_rsrc(**versions.K8S_SERVICE, 
+    service = api.get_custom_rsrc(**versions.K8S_SERVICE,
                                   namespace=namespace, name=name)
     return api.success_response("service", service)
 
@@ -136,7 +136,7 @@ def get_kubernetes_service(namespace, name):
 @bp.route("/api/namespaces/<namespace>/hpas/<name>")
 def get_kubernetes_hpa(namespace, name):
     """Return a Kubernetes HPA object as json."""
-    hpa = api.get_custom_rsrc(**versions.K8S_HPA, 
+    hpa = api.get_custom_rsrc(**versions.K8S_HPA,
                               namespace=namespace, name=name)
     return api.success_response("hpa", hpa)
 
@@ -147,9 +147,9 @@ def get_raw_deployment_objects(namespace, name, component):
     # First get the InferenceService to verify it's RawDeployment mode
     inference_service = api.get_custom_rsrc(**versions.inference_service_gvk(),
                                             namespace=namespace, name=name)
-    
+
     if not utils.is_raw_deployment(inference_service):
         return api.error_response("InferenceService is not in RawDeployment mode", 400)
-    
+
     objects = utils.get_raw_deployment_objects(inference_service, component)
     return api.success_response("rawDeploymentObjects", objects)

--- a/backend/apps/common/routes/get.py
+++ b/backend/apps/common/routes/get.py
@@ -32,7 +32,9 @@ def get_inference_service(namespace, name):
         )
 
     # deployment mode information to the response
-    inference_service["deploymentMode"] = "RawDeployment" if utils.is_raw_deployment(inference_service) else "Serverless"
+    deployment_mode = ("RawDeployment" if utils.is_raw_deployment(inference_service) 
+                      else "Serverless")
+    inference_service["deploymentMode"] = deployment_mode
 
     return api.success_response("inferenceService", inference_service)
 
@@ -145,13 +147,14 @@ def get_kubernetes_hpa(namespace, name):
 @bp.route("/api/namespaces/<namespace>/inferenceservices/<name>/rawdeployment/<component>")
 def get_raw_deployment_objects(namespace, name, component):
     """Return all Kubernetes native resources for a RawDeployment component."""
-    # First get the InferenceService to verify it's RawDeployment mode
+
     inference_service = api.get_custom_rsrc(
         **versions.inference_service_gvk(),
         namespace=namespace, name=name)
 
     if not utils.is_raw_deployment(inference_service):
-        return api.error_response("InferenceService is not in RawDeployment mode", 400)
+        return api.error_response(
+            "InferenceService is not in RawDeployment mode", 400)
 
     objects = utils.get_raw_deployment_objects(inference_service, component)
     return api.success_response("rawDeploymentObjects", objects)

--- a/backend/apps/common/utils.py
+++ b/backend/apps/common/utils.py
@@ -2,6 +2,7 @@
 import os
 
 from kubeflow.kubeflow.crud_backend import api, helpers, logging
+from . import versions
 
 log = logging.getLogger(__name__)
 
@@ -124,3 +125,81 @@ def get_components_revisions_dict(components, svc):
         )
 
     return revisions_dict
+
+
+def is_raw_deployment(svc):
+    """
+    Check if an InferenceService is using RawDeployment mode.
+    
+    Returns True if the service uses RawDeployment, False for Serverless mode.
+    """
+    annotations = svc.get("metadata", {}).get("annotations", {})
+    
+    # Check for the new KServe annotation
+    deployment_mode = annotations.get("serving.kserve.io/deploymentMode", "")
+    if deployment_mode.lower() == "rawdeployment":
+        return True
+    
+    # Check for legacy annotation (backward compatibility)
+    raw_mode = annotations.get("serving.kubeflow.org/raw", "false")
+    if raw_mode.lower() == "true":
+        return True
+    
+    return False
+
+
+def get_raw_deployment_objects(svc, component):
+    """
+    Get Kubernetes native resources for a RawDeployment InferenceService component.
+    
+    Returns a dictionary with deployment, service, and hpa objects.
+    """
+    namespace = svc["metadata"]["namespace"]
+    svc_name = svc["metadata"]["name"]
+    
+    # RawDeployment resources follow naming convention: {isvc-name}-{component}
+    resource_name = f"{svc_name}-{component}"
+    
+    objects = {
+        "deployment": None,
+        "service": None,
+        "hpa": None,
+    }
+    
+    try:
+        # Get Deployment
+        deployment = api.get_custom_rsrc(
+            **versions.K8S_DEPLOYMENT,
+            namespace=namespace,
+            name=resource_name
+        )
+        objects["deployment"] = deployment
+        log.info(f"Found deployment {resource_name} for component {component}")
+    except Exception as e:
+        log.warning(f"Could not find deployment {resource_name}: {e}")
+    
+    try:
+        # Get Service
+        service = api.get_custom_rsrc(
+            **versions.K8S_SERVICE,
+            namespace=namespace,
+            name=resource_name
+        )
+        objects["service"] = service
+        log.info(f"Found service {resource_name} for component {component}")
+    except Exception as e:
+        log.warning(f"Could not find service {resource_name}: {e}")
+    
+    try:
+        # Get HPA (optional)
+        hpa = api.get_custom_rsrc(
+            **versions.K8S_HPA,
+            namespace=namespace,
+            name=resource_name
+        )
+        objects["hpa"] = hpa
+        log.info(f"Found HPA {resource_name} for component {component}")
+    except Exception as e:
+        log.debug(f"No HPA found for {resource_name}: {e}")
+    
+    return objects

--- a/backend/apps/common/utils.py
+++ b/backend/apps/common/utils.py
@@ -150,7 +150,8 @@ def is_raw_deployment(svc):
 
 def get_raw_deployment_objects(svc, component):
     """
-    Get Kubernetes native resources for a RawDeployment InferenceService component.
+    Get Kubernetes native resources for a RawDeployment InferenceService 
+    component.
 
     Returns a dictionary with deployment, service, and hpa objects.
     """

--- a/backend/apps/common/utils.py
+++ b/backend/apps/common/utils.py
@@ -150,7 +150,7 @@ def is_raw_deployment(svc):
 
 def get_raw_deployment_objects(svc, component):
     """
-    Get Kubernetes native resources for a RawDeployment InferenceService 
+    Get Kubernetes native resources for a RawDeployment InferenceService
     component.
 
     Returns a dictionary with deployment, service, and hpa objects.

--- a/backend/apps/common/utils.py
+++ b/backend/apps/common/utils.py
@@ -130,42 +130,42 @@ def get_components_revisions_dict(components, svc):
 def is_raw_deployment(svc):
     """
     Check if an InferenceService is using RawDeployment mode.
-    
+
     Returns True if the service uses RawDeployment, False for Serverless mode.
     """
     annotations = svc.get("metadata", {}).get("annotations", {})
-    
+
     # Check for the new KServe annotation
     deployment_mode = annotations.get("serving.kserve.io/deploymentMode", "")
     if deployment_mode.lower() == "rawdeployment":
         return True
-    
+
     # Check for legacy annotation (backward compatibility)
     raw_mode = annotations.get("serving.kubeflow.org/raw", "false")
     if raw_mode.lower() == "true":
         return True
-    
+
     return False
 
 
 def get_raw_deployment_objects(svc, component):
     """
     Get Kubernetes native resources for a RawDeployment InferenceService component.
-    
+
     Returns a dictionary with deployment, service, and hpa objects.
     """
     namespace = svc["metadata"]["namespace"]
     svc_name = svc["metadata"]["name"]
-    
+
     # RawDeployment resources follow naming convention: {isvc-name}-{component}
     resource_name = f"{svc_name}-{component}"
-    
+
     objects = {
         "deployment": None,
         "service": None,
         "hpa": None,
     }
-    
+
     try:
         # Get Deployment
         deployment = api.get_custom_rsrc(
@@ -177,7 +177,7 @@ def get_raw_deployment_objects(svc, component):
         log.info(f"Found deployment {resource_name} for component {component}")
     except Exception as e:
         log.warning(f"Could not find deployment {resource_name}: {e}")
-    
+
     try:
         # Get Service
         service = api.get_custom_rsrc(
@@ -189,7 +189,7 @@ def get_raw_deployment_objects(svc, component):
         log.info(f"Found service {resource_name} for component {component}")
     except Exception as e:
         log.warning(f"Could not find service {resource_name}: {e}")
-    
+
     try:
         # Get HPA (optional)
         hpa = api.get_custom_rsrc(
@@ -201,5 +201,5 @@ def get_raw_deployment_objects(svc, component):
         log.info(f"Found HPA {resource_name} for component {component}")
     except Exception as e:
         log.debug(f"No HPA found for {resource_name}: {e}")
-    
+
     return objects

--- a/backend/apps/common/versions.py
+++ b/backend/apps/common/versions.py
@@ -14,6 +14,17 @@ KNATIVE_SERVICE = {"group": "serving.knative.dev",
                    "version": "v1",
                    "kind": "services"}
 
+# Kubernetes native resources for RawDeployment mode
+K8S_DEPLOYMENT = {"group": "apps",
+                  "version": "v1",
+                  "kind": "deployments"}
+K8S_SERVICE = {"group": "",
+               "version": "v1",
+               "kind": "services"}
+K8S_HPA = {"group": "autoscaling",
+           "version": "v2",
+           "kind": "horizontalpodautoscalers"}
+
 
 def inference_service_gvk():
     """

--- a/frontend/src/app/pages/server-info/server-info.component.ts
+++ b/frontend/src/app/pages/server-info/server-info.component.ts
@@ -248,16 +248,21 @@ export class ServerInfoComponent implements OnInit, OnDestroy {
 
     // Check if this is a RawDeployment InferenceService
     const isRawDeployment = this.isRawDeployment(svc);
-    
+
     if (isRawDeployment) {
       // Handle RawDeployment mode
-      return this.backend.getRawDeploymentObjects(this.namespace, svc.metadata.name, component).pipe(
-        map(objects => [component, objects]),
-        catchError(error => {
-          console.error(`Error fetching RawDeployment objects for ${component}:`, error);
-          return of([component, {}]);
-        })
-      );
+      return this.backend
+        .getRawDeploymentObjects(this.namespace, svc.metadata.name, component)
+        .pipe(
+          map(objects => [component, objects]),
+          catchError(error => {
+            console.error(
+              `Error fetching RawDeployment objects for ${component}:`,
+              error,
+            );
+            return of([component, {}]);
+          }),
+        );
     } else {
       // Handle Serverless mode
       const revName = svc.status.components[component].latestCreatedRevision;
@@ -306,19 +311,20 @@ export class ServerInfoComponent implements OnInit, OnDestroy {
 
   private isRawDeployment(svc: InferenceServiceK8s): boolean {
     const annotations = svc.metadata?.annotations || {};
-    
+
     // Check for the KServe annotation
-    const deploymentMode = annotations['serving.kserve.io/deploymentMode'] || '';
+    const deploymentMode =
+      annotations['serving.kserve.io/deploymentMode'] || '';
     if (deploymentMode.toLowerCase() === 'rawdeployment') {
       return true;
     }
-    
+
     // Check for legacy annotation
     const rawMode = annotations['serving.kubeflow.org/raw'] || 'false';
     if (rawMode.toLowerCase() === 'true') {
       return true;
     }
-    
+
     return false;
   }
 }

--- a/frontend/src/app/pages/server-info/server-info.component.ts
+++ b/frontend/src/app/pages/server-info/server-info.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Observable, of, forkJoin, Subscription } from 'rxjs';
-import { tap, map, concatMap, timeout } from 'rxjs/operators';
+import { tap, map, concatMap, timeout, catchError } from 'rxjs/operators';
 import { Router, ActivatedRoute } from '@angular/router';
 import {
   NamespaceService,
@@ -246,46 +246,79 @@ export class ServerInfoComponent implements OnInit, OnDestroy {
       return of([component, {}]);
     }
 
-    const revName = svc.status.components[component].latestCreatedRevision;
-    const objects: ComponentOwnedObjects = {
-      revision: undefined,
-      configuration: undefined,
-      knativeService: undefined,
-      route: undefined,
-    };
+    // Check if this is a RawDeployment InferenceService
+    const isRawDeployment = this.isRawDeployment(svc);
+    
+    if (isRawDeployment) {
+      // Handle RawDeployment mode
+      return this.backend.getRawDeploymentObjects(this.namespace, svc.metadata.name, component).pipe(
+        map(objects => [component, objects]),
+        catchError(error => {
+          console.error(`Error fetching RawDeployment objects for ${component}:`, error);
+          return of([component, {}]);
+        })
+      );
+    } else {
+      // Handle Serverless mode
+      const revName = svc.status.components[component].latestCreatedRevision;
+      const objects: ComponentOwnedObjects = {
+        revision: undefined,
+        configuration: undefined,
+        knativeService: undefined,
+        route: undefined,
+      };
 
-    return this.backend.getKnativeRevision(this.namespace, revName).pipe(
-      tap(r => (objects.revision = r)),
+      return this.backend.getKnativeRevision(this.namespace, revName).pipe(
+        tap(r => (objects.revision = r)),
 
-      // GET the configuration
-      map(r => {
-        return r.metadata.ownerReferences[0].name;
-      }),
-      concatMap(confName => {
-        return this.backend.getKnativeConfiguration(this.namespace, confName);
-      }),
-      tap(c => (objects.configuration = c)),
+        // GET the configuration
+        map(r => {
+          return r.metadata.ownerReferences[0].name;
+        }),
+        concatMap(confName => {
+          return this.backend.getKnativeConfiguration(this.namespace, confName);
+        }),
+        tap(c => (objects.configuration = c)),
 
-      // GET the Knative service
-      map(c => {
-        return c.metadata.ownerReferences[0].name;
-      }),
-      concatMap(svcName => {
-        return this.backend.getKnativeService(this.namespace, svcName);
-      }),
-      tap(knativeSvc => (objects.knativeService = knativeSvc)),
+        // GET the Knative service
+        map(c => {
+          return c.metadata.ownerReferences[0].name;
+        }),
+        concatMap(svcName => {
+          return this.backend.getKnativeService(this.namespace, svcName);
+        }),
+        tap(knativeSvc => (objects.knativeService = knativeSvc)),
 
-      // GET the Knative route
-      map(knativeSvc => {
-        return knativeSvc.metadata.name;
-      }),
-      concatMap(routeName => {
-        return this.backend.getKnativeRoute(this.namespace, routeName);
-      }),
-      tap(route => (objects.route = route)),
+        // GET the Knative route
+        map(knativeSvc => {
+          return knativeSvc.metadata.name;
+        }),
+        concatMap(routeName => {
+          return this.backend.getKnativeRoute(this.namespace, routeName);
+        }),
+        tap(route => (objects.route = route)),
 
-      // return the final list of objects
-      map(_ => [component, objects]),
-    );
+        // return the final list of objects
+        map(_ => [component, objects]),
+      );
+    }
+  }
+
+  private isRawDeployment(svc: InferenceServiceK8s): boolean {
+    const annotations = svc.metadata?.annotations || {};
+    
+    // Check for the KServe annotation
+    const deploymentMode = annotations['serving.kserve.io/deploymentMode'] || '';
+    if (deploymentMode.toLowerCase() === 'rawdeployment') {
+      return true;
+    }
+    
+    // Check for legacy annotation
+    const rawMode = annotations['serving.kubeflow.org/raw'] || 'false';
+    if (rawMode.toLowerCase() === 'true') {
+      return true;
+    }
+    
+    return false;
   }
 }

--- a/frontend/src/app/services/backend.service.ts
+++ b/frontend/src/app/services/backend.service.ts
@@ -185,6 +185,66 @@ export class MWABackendService extends BackendService {
   }
 
   /*
+   * RawDeployment mode methods
+   */
+  public getKubernetesDeployment(
+    namespace: string,
+    name: string,
+  ): Observable<K8sObject> {
+    const url = `api/namespaces/${namespace}/deployments/${name}`;
+
+    return this.http.get<MWABackendResponse>(url).pipe(
+      catchError(error => this.handleError(error)),
+      map((resp: MWABackendResponse) => {
+        return resp.deployment;
+      }),
+    );
+  }
+
+  public getKubernetesService(
+    namespace: string,
+    name: string,
+  ): Observable<K8sObject> {
+    const url = `api/namespaces/${namespace}/services/${name}`;
+
+    return this.http.get<MWABackendResponse>(url).pipe(
+      catchError(error => this.handleError(error)),
+      map((resp: MWABackendResponse) => {
+        return resp.service;
+      }),
+    );
+  }
+
+  public getKubernetesHPA(
+    namespace: string,
+    name: string,
+  ): Observable<K8sObject> {
+    const url = `api/namespaces/${namespace}/hpas/${name}`;
+
+    return this.http.get<MWABackendResponse>(url).pipe(
+      catchError(error => this.handleError(error)),
+      map((resp: MWABackendResponse) => {
+        return resp.hpa;
+      }),
+    );
+  }
+
+  public getRawDeploymentObjects(
+    namespace: string,
+    name: string,
+    component: string,
+  ): Observable<any> {
+    const url = `api/namespaces/${namespace}/inferenceservices/${name}/rawdeployment/${component}`;
+
+    return this.http.get<MWABackendResponse>(url).pipe(
+      catchError(error => this.handleError(error)),
+      map((resp: MWABackendResponse) => {
+        return resp.rawDeploymentObjects;
+      }),
+    );
+  }
+
+  /*
    * DELETE
    */
   public deleteInferenceService(

--- a/frontend/src/app/types/backend.ts
+++ b/frontend/src/app/types/backend.ts
@@ -11,6 +11,10 @@ export interface MWABackendResponse extends BackendResponse {
   knativeRoute?: K8sObject;
   serviceLogs?: InferenceServiceLogs;
   events?: EventObject[];
+  deployment?: K8sObject;
+  service?: K8sObject;
+  hpa?: K8sObject;
+  rawDeploymentObjects?: RawDeploymentObjects;
 }
 
 export interface InferenceServiceLogs {
@@ -31,4 +35,17 @@ export interface ComponentOwnedObjects {
   configuration: K8sObject;
   knativeService: K8sObject;
   route: K8sObject;
+}
+
+// RawDeployment mode types
+export interface RawDeploymentObjects {
+  deployment?: K8sObject;
+  service?: K8sObject;
+  hpa?: K8sObject;
+}
+
+export interface RawComponentOwnedObjects {
+  deployment?: K8sObject;
+  service?: K8sObject;
+  hpa?: K8sObject;
 }


### PR DESCRIPTION
Fixes: https://github.com/kserve/models-web-app/issues/124

## Summary

This PR fixes a bug where the KServe Endpoints UI would crash with a `404 Not Found` error when trying to view the details of an `InferenceService` deployed in `RawDeployment` mode.

The root cause is that the details page was designed to fetch and display Knative `Revision` objects, which do not exist for models in `RawDeployment` mode. This resulted in the UI trying to access an endpoint at `.../revisions/undefined`, which caused the error.

This change introduces logic to detect if an `InferenceService` is a raw deployment and renders a details page with the available information, preventing the crash and improving the user experience.

---
## How the Fix Works

The implementation checks for the presence of the `serving.kserve.io/deploymentMode: "RawDeployment"` annotation on the `InferenceService` resource.

-   If the annotation is **not** present, the UI behaves as before, fetching and displaying Knative revision details.
-   If the annotation **is** present, the UI bypasses the logic that looks for Knative `Revisions`. Instead, it renders a simplified details view that displays the core `InferenceService` metadata and status without trying to load non-existent revision information.

---
## How This Was Tested

I tested this fix by performing the following steps:

1.  Deployed a standard `InferenceService` (Knative mode) and confirmed its details page still loads and functions correctly.
2.  Clicked on the `RawDeployment` model and confirmed that the details page now loads successfully without any `404` errors.
3.  Confirmed the new details page displays the correct name, namespace, URL, and status for the raw deployment model.

---
## Screenshots

<img width="720" height="459" alt="image" src="https://github.com/user-attachments/assets/3fee7b9d-5b6c-4d12-bf9c-4076d5ea33c9" />
<img width="719" height="395" alt="image" src="https://github.com/user-attachments/assets/5660b00b-4a26-4725-b9fa-f0f63bf5e132" />
