### PR TITLE
Fix URL construction for inference service details for all namespaces

### DIFF
--- a/frontend/src/app/pages/index/index.component.ts
+++ b/frontend/src/app/pages/index/index.component.ts
@@ -190,7 +190,7 @@ export class IndexComponent implements OnInit, OnDestroy {
     svc.ui.protocolVersion = predictor.protocolVersion || 'v1';
     svc.ui.link = {
       text: svc.metadata.name,
-      url: `/details/${this.currNamespace}/${svc.metadata.name}`,
+      url: `/details/${svc.metadata.namespace}/${svc.metadata.name}`,
     };
   }
 


### PR DESCRIPTION
fixes: #116 

### Problem:
In the parseInferenceService method, the code was constructing the URL as:
```
url: `/details/${this.currNamespace}/${svc.metadata.name}`
```
When `currNamespace` is an array (in "All namespaces" mode), this resulted in URLs like:
```
/details/auth,cert-manager,default,istio-system,.../example-sklearn-isvc
```

### Solution:
I changed the URL construction to use the individual ISVC's namespace instead:
```
url: `/details/${svc.metadata.namespace}/${svc.metadata.name}`
```
This ensures that regardless of whether a single namespace or "All namespaces" is selected, each ISVC link will always point to the correct URL format.