### PR TITLE
Update README.md and add Makefile for frontend setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ make setup
 
 # Optional: Specify custom Kubeflow repository path. Default: `../../kubeflow` (relative to the frontend directory)
 # make setup KF_REPO=/path/to/kubeflow
+# Clean Command: Provides a make clean target to remove node_modules
+# make clean
 
 # Build and watch for changes
 npm run build:watch

--- a/README.md
+++ b/README.md
@@ -8,22 +8,25 @@ The web application currently works with `v1beta1` versions of `InferenceService
 
 The web application is installed alongside the other KServe components, either in the `kserve` or in the `kubeflow` namespace. There is a `VirtualService` that exposes the application via an Istio Ingress Gateway. Depending on the installation environment the following Ingress Gateway will be used.
 
-| Installation mode | IngressGateway |
-| - | - |
+| Installation mode | IngressGateway                          |
+| ----------------- | --------------------------------------- |
 | Standalone KServe | knative-ingress-gateway.knative-serving |
-| Kubeflow | kubeflow-gateway.kubeflow |
+| Kubeflow          | kubeflow-gateway.kubeflow               |
 
 To access the application you will need to navigate with your browser to
+
 ```sh
 ${INGRESS_IP}/models/
 ```
 
 Alternatively you can access the application via `kubectl port-forward`. In that case you will need to configure the application to:
+
 1. Not perform any authorization checks, since there is no logged in user
 2. Work under the `/` prefix
 3. Disable Secure cookies, since the app will be exposed under plain http
 
 You can apply the mentioned configurations by doing the following commands:
+
 ```bash
 # edit the configmap
 # CONFIG=config/overlays/kubeflow/kustomization.yaml
@@ -62,16 +65,36 @@ This web application is utilizing common code from the [kubeflow/kubeflow](https
 This will require us to fetch this common code when we want to either build the application locally or in an OCI container image.
 
 In order to run the application locally you will need to:
+
 1. Build the frontend, in watch mode
 2. Run the backend
 
 The `npm run build:watch` command will build the frontend artifacts inside the backend's `static` folder for serving. So in order to see the application you will need to start the backend and connect to `localhost:5000`.
 
 Requirements:
-* node 22.0.0
-* python 3.12
+
+- node 22.0.0
+- python 3.12
 
 ### Frontend
+
+#### Option 1: Using Makefile (Recommended)
+
+```bash
+cd $KSERVE_MODELS_WEB_APPLICATION_REPOSITORY/frontend
+
+# Setup dependencies and build common library
+make setup
+
+# Optional: Specify custom Kubeflow repository path. Default: `../../kubeflow` (relative to the frontend directory)
+# make setup KF_REPO=/path/to/kubeflow
+
+# Build and watch for changes
+npm run build:watch
+```
+
+#### Option 2: Manual setup
+
 ```bash
 # build the common library
 COMMIT=$(cat ./frontend/COMMIT)
@@ -93,6 +116,7 @@ npm run build:watch
 ### Backend
 
 #### run it locally
+
 ```bash
 # create a virtual environment and install dependencies
 # https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/
@@ -101,10 +125,9 @@ python3.12 -m pip install --user virtualenv
 python3.12 -m venv web-application-development
 source web-application-development/bin/activate
 
-# install the dependencies on the activated virtual environment 
+# install the dependencies on the activated virtual environment
 KUBEFLOW_REPOSITORY="/path/to/kubeflow/kubeflow" make -C backend install-deps
 
 # run the backend
 make -C backend run-dev
 ```
-

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,0 +1,51 @@
+# Minimal Makefile for frontend setup
+# Usage examples:
+#   make setup
+#   make setup KUBEFLOW_REPOSITORY=/path/to/kubeflow
+#   make setup KF_REPO=/path/to/kubeflow
+
+# Allow multiple var names; first non-empty wins, default to ../kubeflow
+KUBEFLOW_REPOSITORY ?= $(or $(KF_REPO),../../kubeflow)
+KUBEFLOW_REMOTE ?= https://github.com/kubeflow/kubeflow
+
+COMMIT_FILE := ./COMMIT
+COMMON_LIB_DIR := $(KUBEFLOW_REPOSITORY)/components/crud-web-apps/common/frontend/kubeflow-common-lib
+COMMON_LIB_DIST := $(COMMON_LIB_DIR)/dist/kubeflow
+
+.PHONY: all setup clean
+
+all: setup
+
+setup:
+	@echo ">> Using KUBEFLOW_REPOSITORY=$(KUBEFLOW_REPOSITORY)"
+	@if [ ! -f "$(COMMIT_FILE)" ]; then echo "Missing $(COMMIT_FILE) in frontend/"; exit 1; fi
+	@if [ ! -d "$(KUBEFLOW_REPOSITORY)/.git" ]; then \
+	    echo "Cloning $(KUBEFLOW_REMOTE) into $(KUBEFLOW_REPOSITORY)"; \
+	    git clone "$(KUBEFLOW_REMOTE)" "$(KUBEFLOW_REPOSITORY)"; \
+	fi
+	@if [ ! -d "$(COMMON_LIB_DIR)" ]; then \
+	    echo "Expected common lib at: $(COMMON_LIB_DIR)"; \
+	    echo "Verify KUBEFLOW_REPOSITORY is correct."; \
+	    exit 1; \
+	fi
+	@echo ">> Checking kubeflow-common-lib status"
+	@TARGET_COMMIT=$$(cat "$(COMMIT_FILE)"); \
+	if [ -d "$(COMMON_LIB_DIST)" ] && [ "$$(cd "$(COMMON_LIB_DIR)" && git rev-parse HEAD)" = "$$(cd "$(COMMON_LIB_DIR)" && git rev-parse "$$TARGET_COMMIT")" ]; then \
+	    echo ">> kubeflow-common-lib is up-to-date at commit $$TARGET_COMMIT; skipping build"; \
+	else \
+	    echo ">> Building kubeflow-common-lib at commit $$TARGET_COMMIT"; \
+	    cd "$(COMMON_LIB_DIR)" && \
+	    git fetch --all --tags && \
+	    git checkout "$$TARGET_COMMIT" && \
+	    npm install && \
+	    npm run build; \
+	fi
+	@cd "$(COMMON_LIB_DIR)" && cd dist/kubeflow && npm link
+	@echo ">> Installing frontend deps and linking kubeflow-common-lib"
+	@npm install
+	@npm link kubeflow
+	@echo "✔ Setup complete. Now run: npm run build:watch"
+
+clean:
+	@echo ">> Cleaning frontend node_modules"
+	@rm -rf node_modules

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -8,8 +8,8 @@ KUBEFLOW_REPOSITORY ?= $(or $(KF_REPO),../../kubeflow)
 KUBEFLOW_REMOTE ?= https://github.com/kubeflow/kubeflow
 
 COMMIT_FILE := ./COMMIT
-COMMON_LIB_DIR := $(KUBEFLOW_REPOSITORY)/components/crud-web-apps/common/frontend/kubeflow-common-lib
-COMMON_LIB_DIST := $(COMMON_LIB_DIR)/dist/kubeflow
+COMMON_LIBRARY_DIRECTORY := $(KUBEFLOW_REPOSITORY)/components/crud-web-apps/common/frontend/kubeflow-common-lib
+COMMON_LIBRARY_DISTRIBUTION := $(COMMON_LIBRARY_DIRECTORY)/dist/kubeflow
 
 .PHONY: all setup clean
 
@@ -22,25 +22,25 @@ setup:
 	    echo "Cloning $(KUBEFLOW_REMOTE) into $(KUBEFLOW_REPOSITORY)"; \
 	    git clone "$(KUBEFLOW_REMOTE)" "$(KUBEFLOW_REPOSITORY)"; \
 	fi
-	@if [ ! -d "$(COMMON_LIB_DIR)" ]; then \
-	    echo "Expected common lib at: $(COMMON_LIB_DIR)"; \
+	@if [ ! -d "$(COMMON_LIBRARY_DIRECTORY)" ]; then \
+	    echo "Expected common lib at: $(COMMON_LIBRARY_DIRECTORY)"; \
 	    echo "Verify KUBEFLOW_REPOSITORY is correct."; \
 	    exit 1; \
 	fi
 	@echo ">> Checking kubeflow-common-lib status"
 	@TARGET_COMMIT=$$(cat "$(COMMIT_FILE)"); \
-	if [ -d "$(COMMON_LIB_DIST)" ] && [ "$$(cd "$(COMMON_LIB_DIR)" && git rev-parse HEAD)" = "$$(cd "$(COMMON_LIB_DIR)" && git rev-parse "$$TARGET_COMMIT")" ]; then \
-	    echo ">> kubeflow-common-lib is up-to-date at commit $$TARGET_COMMIT; skipping build"; \
+	if [ -d "$(COMMON_LIBRARY_DISTRIBUTION)" ] && [ "$$(cd "$(COMMON_LIBRARY_DIRECTORY)" && git rev-parse HEAD)" = "$$(cd "$(COMMON_LIBRARY_DIRECTORY)" && git rev-parse "$$TARGET_COMMIT")" ]; then \
+	    echo ">> kubeflow-common-library is up-to-date at commit $$TARGET_COMMIT; skipping build"; \
 	else \
-	    echo ">> Building kubeflow-common-lib at commit $$TARGET_COMMIT"; \
-	    cd "$(COMMON_LIB_DIR)" && \
+	    echo ">> Building kubeflow-common-library at commit $$TARGET_COMMIT"; \
+	    cd "$(COMMON_LIBRARY_DIRECTORY)" && \
 	    git fetch --all --tags && \
 	    git checkout "$$TARGET_COMMIT" && \
 	    npm install && \
 	    npm run build; \
 	fi
-	@cd "$(COMMON_LIB_DIR)" && cd dist/kubeflow && npm link
-	@echo ">> Installing frontend deps and linking kubeflow-common-lib"
+	@cd "$(COMMON_LIBRARY_DIRECTORY)" && cd dist/kubeflow && npm link
+	@echo ">> Installing frontend dependencies and linking kubeflow-common-library"
 	@npm install
 	@npm link kubeflow
 	@echo "✔ Setup complete. Now run: npm run build:watch"

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,10 +1,9 @@
-# Minimal Makefile for frontend setup
+# Makefile for frontend setup
 # Usage examples:
 #   make setup
 #   make setup KUBEFLOW_REPOSITORY=/path/to/kubeflow
 #   make setup KF_REPO=/path/to/kubeflow
 
-# Allow multiple var names; first non-empty wins, default to ../kubeflow
 KUBEFLOW_REPOSITORY ?= $(or $(KF_REPO),../../kubeflow)
 KUBEFLOW_REMOTE ?= https://github.com/kubeflow/kubeflow
 


### PR DESCRIPTION
### Summary
This PR introduces a`Makefile` to the frontend directory to streamline the setup and development workflow for the Models Web Application frontend. Fixes #132 

### Features
#### Automated Setup:

- Clones the Kubeflow repository if not present.
- Checks out the correct commit for the shared kubeflow-common-lib based on the COMMIT file.
- Builds and links the common library only if needed (with smart caching based on commit hash).
- Installs frontend dependencies and links the common library.

#### Environment Variable Support:
Allows overriding the default Kubeflow repository location via the KUBEFLOW_REPOSITORY environment variable (defaults to ../../kubeflow).
#### Clean Command:
Provides a make clean target to remove node_modules.