### PR TITLE
chore: deprecate 'rawdeployment' in favor of 'standard' mode

### DIFF
--- a/backend/apps/common/routes/get.py
+++ b/backend/apps/common/routes/get.py
@@ -52,8 +52,8 @@ def get_inference_service_logs(svc):
     if deployment_mode == "ModelMesh":
         # For ModelMesh, get logs from modelmesh-serving deployment
         component_pods_dict = utils.get_modelmesh_pods(svc, components)
-    elif deployment_mode == "RawDeployment":
-        component_pods_dict = utils.get_raw_inference_service_pods(svc, components)
+    elif deployment_mode == "Standard":
+        component_pods_dict = utils.get_standard_inference_service_pods(svc, components)
     else:
         # Serverless mode
         component_pods_dict = utils.get_inference_service_pods(svc, components)
@@ -122,7 +122,7 @@ def get_inference_service_events(namespace, name):
     )
 
 
-# RawDeployment mode endpoints
+# Standard mode endpoints
 @bp.route("/api/namespaces/<namespace>/deployments/<name>")
 def get_kubernetes_deployment(namespace, name):
     """Return a Kubernetes Deployment object as json."""
@@ -149,20 +149,20 @@ def get_kubernetes_hpa(namespace, name):
 
 
 @bp.route(
-    "/api/namespaces/<namespace>/inferenceservices/<name>/" "rawdeployment/<component>"
+    "/api/namespaces/<namespace>/inferenceservices/<name>/" "standard/<component>"
 )
-def get_raw_deployment_objects(namespace, name, component):
-    """Return all Kubernetes native resources for a RawDeployment component."""
+def get_standard_deployment_objects(namespace, name, component):
+    """Return all Kubernetes native resources for a Standard component."""
 
     inference_service = api.get_custom_rsrc(
         **versions.inference_service_gvk(), namespace=namespace, name=name
     )
 
-    if not utils.is_raw_deployment(inference_service):
-        return api.error_response("InferenceService is not in RawDeployment mode", 400)
+    if not utils.is_standard_deployment(inference_service):
+        return api.error_response("InferenceService is not in Standard mode", 400)
 
-    objects = utils.get_raw_deployment_objects(inference_service, component)
-    return api.success_response("rawDeploymentObjects", objects)
+    objects = utils.get_standard_deployment_objects(inference_service, component)
+    return api.success_response("standardDeploymentObjects", objects)
 
 
 @bp.route(

--- a/backend/apps/common/versions.py
+++ b/backend/apps/common/versions.py
@@ -15,7 +15,7 @@ KNATIVE_CONF = {
 }
 KNATIVE_SERVICE = {"group": "serving.knative.dev", "version": "v1", "kind": "services"}
 
-# Kubernetes native resources for RawDeployment mode
+# Kubernetes native resources for Standard mode
 K8S_DEPLOYMENT = {"group": "apps", "version": "v1", "kind": "deployments"}
 K8S_SERVICE = {"group": "", "version": "v1", "kind": "services"}
 K8S_HPA = {"group": "autoscaling", "version": "v2", "kind": "horizontalpodautoscalers"}

--- a/frontend/src/app/pages/server-info/server-info.component.ts
+++ b/frontend/src/app/pages/server-info/server-info.component.ts
@@ -262,10 +262,10 @@ export class ServerInfoComponent implements OnInit, OnDestroy {
             return of([component, {}]);
           }),
         );
-    } else if (deploymentMode === 'RawDeployment') {
-      // Handle RawDeployment mode
+    } else if (deploymentMode === 'Standard') {
+      // Handle Standard mode
       return this.backend
-        .getRawDeploymentObjects(
+        .getStandardDeploymentObjects(
           this.namespace,
           inferenceService.metadata.name,
           component,
@@ -274,7 +274,7 @@ export class ServerInfoComponent implements OnInit, OnDestroy {
           map(objects => [component, objects]),
           catchError(error => {
             console.error(
-              `Error fetching RawDeployment objects for ${component}:`,
+              `Error fetching Standard objects for ${component}:`,
               error,
             );
             return of([component, {}]);
@@ -358,13 +358,17 @@ export class ServerInfoComponent implements OnInit, OnDestroy {
       });
   }
 
-  private isRawDeployment(inferenceService: InferenceServiceK8s): boolean {
+  private isStandardDeployment(inferenceService: InferenceServiceK8s): boolean {
     const annotations = inferenceService.metadata?.annotations || {};
 
     // Check for the KServe annotation
     const deploymentMode =
       annotations['serving.kserve.io/deploymentMode'] || '';
-    if (deploymentMode.toLowerCase() === 'rawdeployment') {
+    // allowing rawdeployment for backward compatibility
+    if (
+      deploymentMode.toLowerCase() === 'rawdeployment' ||
+      deploymentMode.toLowerCase() === 'standard'
+    ) {
       return true;
     }
 
@@ -389,8 +393,8 @@ export class ServerInfoComponent implements OnInit, OnDestroy {
   private getDeploymentMode(inferenceService: InferenceServiceK8s): string {
     if (this.isModelMeshDeployment(inferenceService)) {
       return 'ModelMesh';
-    } else if (this.isRawDeployment(inferenceService)) {
-      return 'RawDeployment';
+    } else if (this.isStandardDeployment(inferenceService)) {
+      return 'Standard';
     } else {
       return 'Serverless';
     }

--- a/frontend/src/app/services/backend.service.ts
+++ b/frontend/src/app/services/backend.service.ts
@@ -185,7 +185,7 @@ export class MWABackendService extends BackendService {
   }
 
   /*
-   * RawDeployment mode methods
+   * Standard mode methods
    */
   public getKubernetesDeployment(
     namespace: string,
@@ -229,17 +229,17 @@ export class MWABackendService extends BackendService {
     );
   }
 
-  public getRawDeploymentObjects(
+  public getStandardDeploymentObjects(
     namespace: string,
     name: string,
     component: string,
   ): Observable<any> {
-    const url = `api/namespaces/${namespace}/inferenceservices/${name}/rawdeployment/${component}`;
+    const url = `api/namespaces/${namespace}/inferenceservices/${name}/standard/${component}`;
 
     return this.http.get<MWABackendResponse>(url).pipe(
       catchError(error => this.handleError(error)),
       map((resp: MWABackendResponse) => {
-        return resp.rawDeploymentObjects;
+        return resp.standardDeploymentObjects;
       }),
     );
   }

--- a/frontend/src/app/types/backend.ts
+++ b/frontend/src/app/types/backend.ts
@@ -14,7 +14,7 @@ export interface MWABackendResponse extends BackendResponse {
   deployment?: K8sObject;
   service?: K8sObject;
   hpa?: K8sObject;
-  rawDeploymentObjects?: RawDeploymentObjects;
+  standardDeploymentObjects?: StandardDeploymentObjects;
   modelmeshObjects?: ModelMeshObjects;
 }
 
@@ -38,8 +38,8 @@ export interface ComponentOwnedObjects {
   route: K8sObject;
 }
 
-// RawDeployment mode types
-export interface RawDeploymentObjects {
+// Standard mode types
+export interface StandardDeploymentObjects {
   deployment?: K8sObject;
   service?: K8sObject;
   hpa?: K8sObject;


### PR DESCRIPTION
Found a ~~bug~~ (not really a bug, see https://github.com/kserve/models-web-app/pull/148#issuecomment-3830949581) where the model web app kept looking for `KNative` `revisions` with KServe 0.16.0, if the documentation is followed and you deploy KServe in `Standard` mode.

This should bring the models web app in line with KServe in handling `RawDeployment` and `Standard` in annotations on `InferenceService`s.

See https://github.com/kserve/kserve/commit/92899a1f6ba2644bcfb7b828c00f22732c17f6be from the KServe repository.