### PR TITLE
Fix pre-commit yaml linting errors

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -7,10 +7,10 @@ rules:
   document-end:
     present: false
   indentation:
-    indent-sequences: false
+    indent-sequences: consistent
   line-length:
     max: 400
   truthy:
-    allowed-values: ['on', 'off', 'true', 'false']
-  empty-lines: 
+    allowed-values: ["on", "off", "true", "false"]
+  empty-lines:
     level: warning


### PR DESCRIPTION
Added proper indentation in the yml files.

<img width="1154" height="224" alt="image" src="https://github.com/user-attachments/assets/c58412c9-4f0d-4225-8331-f92879e0e05a" />
