### PR TITLE
Fix header size limits for large JWT tokens with oauth2-proxy

### DIFF
--- a/backend/apps/common/__init__.py
+++ b/backend/apps/common/__init__.py
@@ -4,6 +4,7 @@ import kubeflow.kubeflow.crud_backend as base
 from kubeflow.kubeflow.crud_backend import config, logging
 
 from .routes import bp as routes_bp
+from .jwt_middleware import register_jwt_middleware
 
 log = logging.getLogger(__name__)
 
@@ -13,6 +14,9 @@ def create_app(name=__name__, static_folder="static", cfg: config.Config = None)
     cfg = config.Config() if cfg is None else cfg
 
     app = base.create_app(name, static_folder, cfg)
+
+    # Register JWT middleware for better error handling
+    register_jwt_middleware(app)
 
     # Register the app's blueprints
     app.register_blueprint(routes_bp)

--- a/backend/apps/common/jwt_middleware.py
+++ b/backend/apps/common/jwt_middleware.py
@@ -1,0 +1,64 @@
+"""JWT size middleware."""
+
+import os
+from flask import request, jsonify
+from werkzeug.exceptions import BadRequest
+from kubeflow.kubeflow.crud_backend import logging
+
+log = logging.getLogger(__name__)
+
+JWT_WARNING_THRESHOLD = int(os.environ.get("JWT_WARNING_THRESHOLD", "16000"))
+JWT_ERROR_THRESHOLD = int(os.environ.get("JWT_ERROR_THRESHOLD", "28000"))
+
+
+def register_jwt_middleware(app):
+    @app.before_request
+    def check_jwt_size():
+        try:
+            auth_header = request.headers.get('Authorization', '')
+            userid_header_name = os.environ.get('USERID_HEADER', 'kubeflow-userid')
+            userid_header = request.headers.get(userid_header_name, '')
+            
+            jwt_headers_size = len(auth_header) + len(userid_header)
+            total_headers_size = sum(len(k) + len(v) for k, v in request.headers)
+            
+            log.debug(f"Headers analysis - Total: {total_headers_size}, JWT: {jwt_headers_size}")
+            
+            if jwt_headers_size > JWT_ERROR_THRESHOLD:
+                error_msg = {
+                    "error": "JWT token too large",
+                    "message": "JWT token size exceeds server limits. This typically occurs with identity providers like Azure AD when users have many group memberships.",
+                    "details": {
+                        "size": jwt_headers_size,
+                        "threshold": JWT_ERROR_THRESHOLD
+                    }
+                }
+                log.error(f"JWT token size {jwt_headers_size} exceeds threshold {JWT_ERROR_THRESHOLD}")
+                return jsonify(error_msg), 413
+            
+            elif jwt_headers_size > JWT_WARNING_THRESHOLD:
+                log.warning(f"Large JWT token detected: {jwt_headers_size} bytes")
+                
+        except Exception as e:
+            log.error(f"JWT middleware error: {str(e)}")
+            
+        return None
+    
+    @app.errorhandler(BadRequest)
+    def handle_bad_request(error):
+        try:
+            if hasattr(request, 'headers'):
+                total_headers_size = sum(len(k) + len(v) for k, v in request.headers)
+                if total_headers_size > JWT_WARNING_THRESHOLD:
+                    log.error(f"Bad request with large headers: {total_headers_size} bytes")
+                    return jsonify({
+                        "error": "Request headers too large",
+                        "message": "Request could not be processed due to large headers"
+                    }), 400
+        except Exception as e:
+            log.error(f"Bad request handler error: {str(e)}")
+        
+        return jsonify({
+            "error": "Bad Request", 
+            "message": "The server could not understand the request"
+        }), 400

--- a/config/base/deployment.yaml
+++ b/config/base/deployment.yaml
@@ -21,6 +21,9 @@ spec:
       - image: kserve/models-web-app:latest
         imagePullPolicy: Always
         name: kserve-models-web-app
+        env:
+          - name: GUNICORN_CMD_ARGS
+            value: --limit-request-field_size 32000
         envFrom:
           - configMapRef:
               name: kserve-models-web-app-config

--- a/config/examples/large-jwt-config.yaml
+++ b/config/examples/large-jwt-config.yaml
@@ -1,0 +1,28 @@
+# Configuration for large JWT token handling
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kserve-models-web-app-config
+  namespace: kserve
+data:
+  APP_PREFIX: "/models"
+  JWT_WARNING_THRESHOLD: "16000"
+  JWT_ERROR_THRESHOLD: "28000"
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kserve-models-web-app
+  namespace: kserve
+spec:
+  template:
+    spec:
+      containers:
+      - name: kserve-models-web-app
+        env:
+          - name: GUNICORN_CMD_ARGS
+            value: --limit-request-field_size 32000
+        envFrom:
+          - configMapRef:
+              name: kserve-models-web-app-config

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -521,7 +521,6 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-14.3.0.tgz",
       "integrity": "sha512-QoBcIKy1ZiU+4qJsAh5Ls20BupWiXiZzKb0s6L9/dntPt5Msr4Ao289XR2P6O1L+kTsCprH9Kt41zyGQ/bkRqg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -537,7 +536,6 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-14.2.7.tgz",
       "integrity": "sha512-/tEsYaUbDSnfEmKVvAMramIptmhI67O+9STjOV0i+74XR2NospeK0fkbywIANu1n3w6AHGMotvRWJrjmbCElFg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -569,7 +567,6 @@
       "integrity": "sha512-I5EepRem2CCyS3GDzQxZ2ZrqQwVqoGoLY+ZQhsK1QGWUnUyFOjbv3OlUGxRUYwcedu19V1EBAKjmQ96HzMIcVQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@angular-devkit/architect": "0.1402.13",
         "@angular-devkit/core": "14.2.13",
@@ -606,7 +603,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-14.3.0.tgz",
       "integrity": "sha512-pV9oyG3JhGWeQ+TFB0Qub6a1VZWMNZ6/7zEopvYivdqa5yDLLDSBRWb6P80RuONXyGnM1pa7l5nYopX+r/23GQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -623,7 +619,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-14.3.0.tgz",
       "integrity": "sha512-E15Rh0t3vA+bctbKnBCaDmLvc3ix+ZBt6yFZmhZalReQ+KpOlvOJv+L9oiFEgg+rYVl2QdvN7US1fvT0PqswLw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -644,7 +639,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-14.3.0.tgz",
       "integrity": "sha512-eoKpKdQ2X6axMgzcPUMZVYl3bIlTMzMeTo5V29No4BzgiUB+QoOTYGNJZkGRyqTNpwD9uSBJvmT2vG9+eC4ghQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.17.2",
         "chokidar": "^3.0.0",
@@ -675,7 +669,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-14.3.0.tgz",
       "integrity": "sha512-wYiwItc0Uyn4FWZ/OAx/Ubp2/WrD3EgUJ476y1XI7yATGPF8n9Ld5iCXT08HOvc4eBcYlDfh90kTXR6/MfhzdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -692,7 +685,6 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-14.3.0.tgz",
       "integrity": "sha512-fBZZC2UFMom2AZPjGQzROPXFWO6kvCsPDKctjJwClVC8PuMrkm+RRyiYRdBbt2qxWHEqOZM2OCQo73xUyZOYHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -801,7 +793,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-14.3.0.tgz",
       "integrity": "sha512-w9Y3740UmTz44T0Egvc+4QV9sEbO61L+aRHbpkLTJdlEGzHByZvxJmJyBYmdqeyTPwc/Zpy7c02frlpfAlyB7A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -824,7 +815,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-14.3.0.tgz",
       "integrity": "sha512-rneZiMrIiYRhrkQvdL40E2ErKRn4Zdo6EtjBM9pAmWeyoM8oMnOZb9gz5vhrkNWg06kVMVg0yKqluP5How7j3A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -891,7 +881,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.10.tgz",
       "integrity": "sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -3184,7 +3173,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3627,7 +3615,6 @@
       "deprecated": "Please upgrade to 6.1.0. https://fontawesome.com/docs/changelog/",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^0.3.0"
       },
@@ -5190,8 +5177,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/node-forge": {
       "version": "1.3.14",
@@ -5541,7 +5527,6 @@
       "integrity": "sha512-Rg5xwznHWWSy7v2o0cdho6n+xLhK2gntImp0rJroVVFkcYFYQ8C8UJTSuTw/3CnExBmPjycjmUJkxVmjXsld6A==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.30.7",
         "@typescript-eslint/types": "5.30.7",
@@ -6073,7 +6058,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6220,7 +6204,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7147,7 +7130,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -8103,7 +8085,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8487,7 +8468,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cypress/request": "^3.0.9",
         "@cypress/xvfb": "^1.2.4",
@@ -9468,7 +9448,6 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -10181,7 +10160,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -13479,8 +13457,7 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-4.2.0.tgz",
       "integrity": "sha512-OcFpBrIhnbmb9wfI8cqPSJ50pv3Wg4/NSgoZIqHzIwO/2a9qivJWzv8hUvaREIMYYJBas6AvfXATFdVuzzCqVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jasmine-spec-reporter": {
       "version": "7.0.0",
@@ -13561,7 +13538,6 @@
       "integrity": "sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^28.1.3",
         "@jest/types": "^28.1.3",
@@ -15018,7 +14994,6 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -15229,7 +15204,6 @@
       "integrity": "sha512-i/zQLFrfEpRyQoJF9fsCdTMOF5c2dK7C7OmsuKg2D0YSsuZSfQDiLuaiktbuio6F2wiCsZSnSnieIQ0ant/uzQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jasmine-core": "^4.1.0"
       },
@@ -16077,7 +16051,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -17631,7 +17604,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -18340,7 +18312,6 @@
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -18503,7 +18474,6 @@
       "deprecated": "We have news to share - Protractor is deprecated and will reach end-of-life by Summer 2023. To learn more and find out about other options please refer to this post on the Angular blog. Thank you for using and contributing to Protractor. https://goo.gle/state-of-e2e-in-angular",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/q": "^0.0.32",
         "@types/selenium-webdriver": "^3.0.0",
@@ -19746,7 +19716,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
       "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -19838,7 +19807,6 @@
       "integrity": "sha512-3tmF16yvnBwtlPrNBHw/H907j8MlOX8aTBnlNX1yrKx24RKcJGPyLhFUwkoKBKesR3unP93/2z14Ll8NicwQUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -21479,7 +21447,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -21881,7 +21848,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -21937,8 +21903,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -22121,7 +22086,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
       "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22774,7 +22738,6 @@
       "integrity": "sha512-4+YIK4Abzv8172/SGqObnUjaIHjLEuUasz9EwQj/9xmPPkYJy2Mh03Q/lJfSD3YLzbxy5FeTq5Uw0323Oh6SJQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -22897,7 +22860,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -22955,7 +22917,6 @@
       "integrity": "sha512-L5S4Q2zT57SK7tazgzjMiSMBdsw+rGYIX27MgPgx7LDhWO0lViPrHKoLS7jo5In06PWYAhlYu3PbyoC6yAThbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -23012,7 +22973,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -23420,7 +23380,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -23601,7 +23560,6 @@
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.11.8.tgz",
       "integrity": "sha512-82bctBg2hKcEJ21humWIkXRlLBBmrc3nN7DFh5LGGhcyycO2S7FN8NmdvlcKaGFDNVL4/9kFLmwmInTavdJERA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       }


### PR DESCRIPTION
- Add GUNICORN_CMD_ARGS to handle JWT tokens up to 32KB
- Implement JWT middleware for better error handling
- Add configurable thresholds for JWT size warnings and errors
- Update README with Known Issues section
- Add example configuration for large JWT environments

Resolves #155