### PR TITLE
feat: Add support for multi-document YAML in InferenceService creation

### DIFF
--- a/backend/apps/common/versions.py
+++ b/backend/apps/common/versions.py
@@ -51,3 +51,15 @@ def inference_graph_gvk():
         "version": "v1alpha1",
         "kind": "inferencegraphs",
     }
+
+
+def trained_model_gvk():
+    """
+    Return the GVK needed for a TrainedModel.
+
+    """
+    return {
+        "group": "serving.kserve.io",
+        "version": "v1alpha1",
+        "kind": "trainedmodels",
+    }

--- a/backend/apps/v1beta1/routes/post.py
+++ b/backend/apps/v1beta1/routes/post.py
@@ -41,3 +41,16 @@ def post_inference_graph(namespace):
     api.create_custom_rsrc(**gvk, data=customResource, namespace=namespace)
 
     return api.success_response("message", "InferenceGraph successfully created.")
+
+
+@bp.route("/api/namespaces/<namespace>/trainedmodels", methods=["POST"])
+@decorators.request_is_json_type
+@decorators.required_body_params("apiVersion", "kind", "metadata", "spec")
+def post_trained_model(namespace):
+    """Handle creation of a TrainedModel."""
+    customResource = request.get_json()
+
+    gvk = versions.trained_model_gvk()
+    api.create_custom_rsrc(**gvk, data=customResource, namespace=namespace)
+
+    return api.success_response("message", "TrainedModel successfully created.")

--- a/frontend/cypress/e2e/multi-doc-deployment.cy.ts
+++ b/frontend/cypress/e2e/multi-doc-deployment.cy.ts
@@ -1,0 +1,331 @@
+describe('Multi-Document YAML Deployment', () => {
+  const NAMESPACE = 'kubeflow-user';
+  const setComponentState = (yaml: string) => {
+    cy.get('app-submit-form', { timeout: 10000 }).should('exist');
+    cy.window().then((win: any) => {
+      if (!win.ng) return;
+      cy.get('app-submit-form').then($el => {
+        try {
+          const component = win.ng.getComponent($el[0]);
+          if (!component) return;
+          component.yaml = yaml;
+          component.namespace = NAMESPACE;
+          if (win.Zone) {
+            win.Zone.current.run(() => {
+              const appRef = win.ng
+                .getInjector($el[0])
+                .get(win.ng.coreTokens?.ApplicationRef);
+              appRef?.tick();
+            });
+          }
+        } catch (e) {
+          cy.log('Failed to set component state: ' + e);
+        }
+      });
+    });
+  };
+
+  const clickSubmit = () => {
+    cy.get('lib-submit-bar button')
+      .contains(/create/i)
+      .click({ force: true });
+  };
+
+  beforeEach(() => {
+    cy.intercept('GET', '/api/config/namespaces', {
+      fixture: 'namespaces',
+    }).as('getNamespaces');
+
+    cy.intercept('GET', '/api/namespaces/*/inferenceservices', {
+      statusCode: 200,
+      body: [],
+    }).as('getInferenceServices');
+  });
+
+  it('should POST to both /inferenceservices and /trainedmodels for multi-doc YAML', () => {
+    cy.intercept('POST', '/api/namespaces/*/inferenceservices', {
+      statusCode: 201,
+      body: { message: 'InferenceService successfully created.' },
+    }).as('createInferenceService');
+
+    cy.intercept('POST', '/api/namespaces/*/trainedmodels', {
+      statusCode: 201,
+      body: { message: 'TrainedModel successfully created.' },
+    }).as('createTrainedModel');
+
+    cy.visit('/new');
+
+    const multiDocYaml = `apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: triton-mms
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: triton
+      protocolVersion: v2
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: cifar10
+spec:
+  inferenceService: triton-mms
+  model:
+    framework: pytorch
+    storageUri: gs://kfserving-examples/models/torchscript/cifar10
+    memory: 1Gi`;
+
+    setComponentState(multiDocYaml);
+    clickSubmit();
+
+    // Both endpoints must be called exactly once
+    cy.wait('@createInferenceService', { timeout: 10000 })
+      .its('request.body')
+      .should(body => {
+        expect(body.kind).to.eq('InferenceService');
+        expect(body.metadata.name).to.eq('triton-mms');
+        expect(body.metadata.namespace).to.eq(NAMESPACE);
+      });
+
+    cy.wait('@createTrainedModel', { timeout: 10000 })
+      .its('request.body')
+      .should(body => {
+        expect(body.kind).to.eq('TrainedModel');
+        expect(body.metadata.name).to.eq('cifar10');
+        expect(body.metadata.namespace).to.eq(NAMESPACE);
+      });
+  });
+
+  it('should show an error and make no API calls for an unsupported resource kind', () => {
+    cy.intercept('POST', '/api/namespaces/**', cy.spy().as('anyPost'));
+
+    cy.visit('/new');
+
+    const unsupportedKindYaml = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deploy
+spec:
+  replicas: 1`;
+
+    setComponentState(unsupportedKindYaml);
+    clickSubmit();
+
+    // Snackbar must appear with an error about the unsupported kind
+    cy.get('.mat-snack-bar-container', { timeout: 10000 })
+      .should('be.visible')
+      .invoke('text')
+      .should('match', /unsupported resource kind/i);
+
+    // No POST request should have been made
+    cy.get('@anyPost').should('not.have.been.called');
+
+    // Should remain on the /new page
+    cy.url().should('include', '/new');
+  });
+
+  it('should show an error when multi-doc YAML contains no InferenceService', () => {
+    cy.intercept('POST', '/api/namespaces/**', cy.spy().as('anyPost'));
+
+    cy.visit('/new');
+
+    // Only a TrainedModel — no InferenceService document
+    const trainedModelOnlyYaml = `apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: cifar10
+spec:
+  inferenceService: triton-mms
+  model:
+    framework: pytorch
+    storageUri: gs://kfserving-examples/models/torchscript/cifar10
+    memory: 1Gi`;
+
+    setComponentState(trainedModelOnlyYaml);
+    clickSubmit();
+
+    cy.get('.mat-snack-bar-container', { timeout: 10000 })
+      .should('be.visible')
+      .invoke('text')
+      .should('match', /at least one inferenceservice/i);
+
+    cy.get('@anyPost').should('not.have.been.called');
+    cy.url().should('include', '/new');
+  });
+
+  it('should show an error when more than one InferenceService document is present', () => {
+    cy.intercept('POST', '/api/namespaces/**', cy.spy().as('anyPost'));
+
+    cy.visit('/new');
+
+    const twoIsvcYaml = `apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: model-one
+spec:
+  predictor:
+    sklearn:
+      storageUri: gs://example/model1
+---
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: model-two
+spec:
+  predictor:
+    sklearn:
+      storageUri: gs://example/model2`;
+
+    setComponentState(twoIsvcYaml);
+    clickSubmit();
+
+    cy.get('.mat-snack-bar-container', { timeout: 10000 })
+      .should('be.visible')
+      .invoke('text')
+      .should('match', /only one inferenceservice/i);
+
+    cy.get('@anyPost').should('not.have.been.called');
+    cy.url().should('include', '/new');
+  });
+
+  it('should show an error when a TrainedModel is missing spec.inferenceService', () => {
+    cy.intercept('POST', '/api/namespaces/**', cy.spy().as('anyPost'));
+
+    cy.visit('/new');
+
+    const missingRefYaml = `apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: triton-mms
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: triton
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: broken-model
+spec:
+  model:
+    framework: pytorch
+    storageUri: gs://example/model
+    memory: 1Gi`;
+
+    setComponentState(missingRefYaml);
+    clickSubmit();
+
+    cy.get('.mat-snack-bar-container', { timeout: 10000 })
+      .should('be.visible')
+      .invoke('text')
+      .should('match', /spec\.inferenceService/i);
+
+    cy.get('@anyPost').should('not.have.been.called');
+    cy.url().should('include', '/new');
+  });
+
+  it('should handle a 3-document YAML (InferenceService + 2 TrainedModels)', () => {
+    cy.intercept('POST', '/api/namespaces/*/inferenceservices', {
+      statusCode: 201,
+      body: { message: 'InferenceService successfully created.' },
+    }).as('createInferenceService');
+
+    // Capture all TrainedModel POSTs
+    cy.intercept('POST', '/api/namespaces/*/trainedmodels', {
+      statusCode: 201,
+      body: { message: 'TrainedModel successfully created.' },
+    }).as('createTrainedModel');
+
+    cy.visit('/new');
+
+    const threeDocYaml = `apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: triton-mms
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: triton
+      protocolVersion: v2
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: cifar10
+spec:
+  inferenceService: triton-mms
+  model:
+    framework: pytorch
+    storageUri: gs://kfserving-examples/models/torchscript/cifar10
+    memory: 1Gi
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: simple-string
+spec:
+  inferenceService: triton-mms
+  model:
+    framework: tensorflow
+    storageUri: gs://kfserving-examples/models/triton/simple_string
+    memory: 1Gi`;
+
+    setComponentState(threeDocYaml);
+    clickSubmit();
+
+    // InferenceService endpoint must be called
+    cy.wait('@createInferenceService', { timeout: 10000 })
+      .its('request.body.metadata.name')
+      .should('eq', 'triton-mms');
+
+    // At least one TrainedModel endpoint must be called
+    cy.wait('@createTrainedModel', { timeout: 10000 })
+      .its('request.body.kind')
+      .should('eq', 'TrainedModel');
+  });
+
+  it('should keep the user on /new and show an error when the trainedmodels endpoint fails', () => {
+    cy.intercept('POST', '/api/namespaces/*/inferenceservices', {
+      statusCode: 201,
+      body: { message: 'InferenceService successfully created.' },
+    }).as('createInferenceService');
+
+    cy.intercept('POST', '/api/namespaces/*/trainedmodels', {
+      statusCode: 500,
+      body: { log: 'Internal server error creating TrainedModel' },
+    }).as('createTrainedModelError');
+
+    cy.visit('/new');
+
+    const yaml = `apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: triton-mms
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: triton
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: cifar10
+spec:
+  inferenceService: triton-mms
+  model:
+    framework: pytorch
+    storageUri: gs://example/model
+    memory: 1Gi`;
+
+    setComponentState(yaml);
+    clickSubmit();
+
+    cy.get('.mat-snack-bar-container', { timeout: 10000 }).should('be.visible');
+    cy.url().should('include', '/new');
+  });
+});

--- a/frontend/src/app/pages/submit-form/submit-form.component.jest.spec.ts
+++ b/frontend/src/app/pages/submit-form/submit-form.component.jest.spec.ts
@@ -1,0 +1,300 @@
+/// <reference types="jest" />
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NamespaceService, SnackBarService } from 'kubeflow';
+import { of, throwError } from 'rxjs';
+import { SubmitFormComponent } from './submit-form.component';
+import { MWABackendService } from 'src/app/services/backend.service';
+
+const INFERENCE_SERVICE_YAML = `
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: triton-mms
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: triton
+`.trim();
+
+const TRAINED_MODEL_YAML = `
+apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: cifar10
+spec:
+  inferenceService: triton-mms
+  model:
+    framework: pytorch
+    storageUri: gs://kfserving-examples/models/torchscript/cifar10
+    memory: 1Gi
+`.trim();
+
+const MULTI_DOC_YAML = `${INFERENCE_SERVICE_YAML}\n---\n${TRAINED_MODEL_YAML}`;
+
+describe('SubmitFormComponent', () => {
+  let component: SubmitFormComponent;
+  let fixture: ComponentFixture<SubmitFormComponent>;
+  let mockBackend: jest.Mocked<Partial<MWABackendService>>;
+  let mockSnack: { open: jest.Mock };
+  let mockRouter: { navigate: jest.Mock };
+
+  beforeEach(async () => {
+    mockBackend = {
+      postInferenceService: jest.fn().mockReturnValue(of({})),
+      postTrainedModel: jest.fn().mockReturnValue(of({})),
+    };
+    mockSnack = { open: jest.fn() };
+    mockRouter = { navigate: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      declarations: [SubmitFormComponent],
+      imports: [RouterTestingModule],
+      providers: [
+        { provide: MWABackendService, useValue: mockBackend },
+        {
+          provide: NamespaceService,
+          useValue: { getSelectedNamespace: () => of('test-ns') },
+        },
+        { provide: SnackBarService, useValue: mockSnack },
+        { provide: Router, useValue: mockRouter },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SubmitFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create and bind namespace from NamespaceService', () => {
+    expect(component).toBeTruthy();
+    expect(component.namespace).toBe('test-ns');
+  });
+
+  describe('single-document YAML (backward compatibility)', () => {
+    it('should call postInferenceService once and navigate back on success', done => {
+      component.yaml = INFERENCE_SERVICE_YAML;
+
+      component.submit();
+
+      setTimeout(() => {
+        expect(mockBackend.postInferenceService).toHaveBeenCalledTimes(1);
+        expect(mockBackend.postTrainedModel).not.toHaveBeenCalled();
+        expect(mockRouter.navigate).toHaveBeenCalledWith(['']);
+        done();
+      }, 100);
+    });
+
+    it('should show "InferenceService created successfully." for single-doc', done => {
+      component.yaml = INFERENCE_SERVICE_YAML;
+
+      component.submit();
+
+      setTimeout(() => {
+        const msg = mockSnack.open.mock.calls[0][0].data.msg;
+        expect(msg).toBe('InferenceService created successfully.');
+        done();
+      }, 100);
+    });
+  });
+
+  describe('multi-document YAML', () => {
+    it('should call postInferenceService and postTrainedModel for each document', done => {
+      component.yaml = MULTI_DOC_YAML;
+
+      component.submit();
+
+      setTimeout(() => {
+        expect(mockBackend.postInferenceService).toHaveBeenCalledTimes(1);
+        expect(mockBackend.postTrainedModel).toHaveBeenCalledTimes(1);
+        expect(mockRouter.navigate).toHaveBeenCalledWith(['']);
+        done();
+      }, 100);
+    });
+
+    it('should show "N resources created successfully." for multi-doc', done => {
+      component.yaml = MULTI_DOC_YAML;
+
+      component.submit();
+
+      setTimeout(() => {
+        const msg = mockSnack.open.mock.calls[0][0].data.msg;
+        expect(msg).toBe('2 resources created successfully.');
+        done();
+      }, 100);
+    });
+
+    it('should inject the current namespace into every document before POSTing', done => {
+      component.namespace = 'production';
+      component.yaml = MULTI_DOC_YAML;
+
+      component.submit();
+
+      setTimeout(() => {
+        const svc = (mockBackend.postInferenceService as jest.Mock).mock
+          .calls[0][0];
+        expect(svc.metadata.namespace).toBe('production');
+
+        const tm = (mockBackend.postTrainedModel as jest.Mock).mock.calls[0][0];
+        expect(tm.metadata.namespace).toBe('production');
+        done();
+      }, 100);
+    });
+
+    it('should call postTrainedModel for each TrainedModel document', done => {
+      const twoTrainedModels = `${INFERENCE_SERVICE_YAML}
+---
+${TRAINED_MODEL_YAML}
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: simple-string
+spec:
+  inferenceService: triton-mms
+  model:
+    framework: tensorflow
+    storageUri: gs://kfserving-examples/models/triton/simple_string
+    memory: 1Gi`;
+
+      component.yaml = twoTrainedModels;
+
+      component.submit();
+
+      setTimeout(() => {
+        expect(mockBackend.postInferenceService).toHaveBeenCalledTimes(1);
+        expect(mockBackend.postTrainedModel).toHaveBeenCalledTimes(2);
+        expect(mockRouter.navigate).toHaveBeenCalledWith(['']);
+        done();
+      }, 100);
+    });
+  });
+
+  describe('YAML parsing errors', () => {
+    it('should show a snackbar error and not call any API for malformed YAML', () => {
+      component.yaml = 'invalid: yaml: [[[unclosed';
+
+      component.submit();
+
+      expect(mockSnack.open).toHaveBeenCalled();
+      const snackConfig = mockSnack.open.mock.calls[0][0];
+      expect(snackConfig.data.msg).toMatch(/yaml parsing error/i);
+      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
+      expect(component.applying).toBe(false);
+    });
+
+    it('should show an error for empty YAML', () => {
+      component.yaml = '';
+
+      component.submit();
+
+      expect(mockSnack.open).toHaveBeenCalled();
+      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validation', () => {
+    it('should require at least one InferenceService document', () => {
+      component.yaml = TRAINED_MODEL_YAML;
+
+      component.submit();
+
+      expect(mockSnack.open).toHaveBeenCalled();
+      const msg = mockSnack.open.mock.calls[0][0].data.msg;
+      expect(msg).toContain(
+        'At least one InferenceService document is required',
+      );
+      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
+    });
+
+    it('should reject more than one InferenceService in a single submission', () => {
+      component.yaml = `${INFERENCE_SERVICE_YAML}\n---\n${INFERENCE_SERVICE_YAML}`;
+
+      component.submit();
+
+      expect(mockSnack.open).toHaveBeenCalled();
+      const msg = mockSnack.open.mock.calls[0][0].data.msg;
+      expect(msg).toContain('Only one InferenceService document is allowed');
+      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
+    });
+
+    it('should reject unsupported resource kinds', () => {
+      component.yaml = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deploy
+spec:
+  replicas: 1`;
+
+      component.submit();
+
+      expect(mockSnack.open).toHaveBeenCalled();
+      const msg = mockSnack.open.mock.calls[0][0].data.msg;
+      expect(msg).toContain('Unsupported resource kind');
+      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
+    });
+
+    it('should validate InferenceService missing spec.predictor', () => {
+      component.yaml = `apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: no-predictor
+spec: {}`;
+
+      component.submit();
+
+      expect(mockSnack.open).toHaveBeenCalled();
+      const msg = mockSnack.open.mock.calls[0][0].data.msg;
+      expect(msg).toContain('spec.predictor');
+      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
+    });
+
+    it('should validate TrainedModel missing spec.inferenceService', () => {
+      component.yaml = `${INFERENCE_SERVICE_YAML}
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: bad-model
+spec:
+  model:
+    framework: pytorch
+    storageUri: gs://example/model
+    memory: 1Gi`;
+
+      component.submit();
+
+      expect(mockSnack.open).toHaveBeenCalled();
+      const msg = mockSnack.open.mock.calls[0][0].data.msg;
+      expect(msg).toContain('spec.inferenceService');
+      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('backend error handling', () => {
+    it('should show snackbar error and not navigate when backend returns an error', done => {
+      mockBackend.postInferenceService = jest
+        .fn()
+        .mockReturnValue(
+          throwError(() => ({ error: { log: 'Cluster error' } })),
+        );
+
+      component.yaml = INFERENCE_SERVICE_YAML;
+
+      component.submit();
+
+      setTimeout(() => {
+        expect(mockSnack.open).toHaveBeenCalled();
+        const msg = mockSnack.open.mock.calls[0][0].data.msg;
+        expect(msg).toBe('Cluster error');
+        expect(mockRouter.navigate).not.toHaveBeenCalled();
+        expect(component.applying).toBe(false);
+        done();
+      }, 100);
+    });
+  });
+});

--- a/frontend/src/app/pages/submit-form/submit-form.component.ts
+++ b/frontend/src/app/pages/submit-form/submit-form.component.ts
@@ -6,9 +6,12 @@ import {
   SnackBarService,
   SnackType,
 } from 'kubeflow';
-import { load } from 'js-yaml';
+import { loadAll } from 'js-yaml';
+import { forkJoin, Observable } from 'rxjs';
 import { InferenceServiceK8s } from 'src/app/types/kfserving/v1beta1';
+import { TrainedModelK8s } from 'src/app/types/kfserving/v1alpha1';
 import { MWABackendService } from 'src/app/services/backend.service';
+import { MWABackendResponse } from 'src/app/types/backend';
 
 @Component({
   selector: 'app-submit-form',
@@ -40,9 +43,9 @@ export class SubmitFormComponent implements OnInit {
   submit() {
     this.applying = true;
 
-    let customResource: InferenceServiceK8s;
+    let docs: unknown[];
     try {
-      customResource = load(this.yaml) as InferenceServiceK8s;
+      docs = loadAll(this.yaml);
     } catch (e) {
       let msg = 'Could not parse the provided YAML';
 
@@ -55,86 +58,87 @@ export class SubmitFormComponent implements OnInit {
         }
       }
 
-      const config: SnackBarConfig = {
-        data: {
-          msg,
-          snackType: SnackType.Error,
-        },
-        duration: 16000,
-      };
-      this.snack.open(config);
+      this.showError(msg);
       this.applying = false;
       return;
     }
 
-    if (!customResource) {
-      const config: SnackBarConfig = {
-        data: {
-          msg: 'YAML is empty or invalid',
-          snackType: SnackType.Error,
-        },
-        duration: 8000,
-      };
-      this.snack.open(config);
+    const validDocs = docs.filter(d => d != null);
+    if (validDocs.length === 0) {
+      this.showError('YAML is empty or invalid');
       this.applying = false;
       return;
     }
 
     const validationErrors: string[] = [];
+    const inferenceServices: InferenceServiceK8s[] = [];
+    const trainedModels: TrainedModelK8s[] = [];
 
-    if (!customResource.apiVersion) {
-      validationErrors.push('Missing required field: apiVersion');
+    for (const doc of validDocs) {
+      const resource = doc as any;
+      const kind = resource?.kind;
+
+      if (kind === 'InferenceService') {
+        validationErrors.push(...this.validateInferenceService(resource));
+        inferenceServices.push(resource as InferenceServiceK8s);
+      } else if (kind === 'TrainedModel') {
+        validationErrors.push(...this.validateTrainedModel(resource));
+        trainedModels.push(resource as TrainedModelK8s);
+      } else {
+        validationErrors.push(
+          `Unsupported resource kind: "${
+            kind || 'unknown'
+          }". Only InferenceService and TrainedModel are supported.`,
+        );
+      }
     }
-    if (!customResource.kind || customResource.kind !== 'InferenceService') {
+
+    if (inferenceServices.length === 0) {
       validationErrors.push(
-        'Missing or invalid field: kind (must be "InferenceService")',
+        'At least one InferenceService document is required.',
       );
     }
-    if (!customResource.metadata) {
-      validationErrors.push('Missing required field: metadata');
-    } else {
-      if (!customResource.metadata.name) {
-        validationErrors.push('Missing required field: metadata.name');
-      }
-    }
-    if (!customResource.spec) {
-      validationErrors.push('Missing required field: spec');
-    } else {
-      if (!customResource.spec.predictor) {
-        validationErrors.push('Missing required field: spec.predictor');
-      }
+
+    if (inferenceServices.length > 1) {
+      validationErrors.push(
+        'Only one InferenceService document is allowed per submission.',
+      );
     }
 
     if (validationErrors.length > 0) {
-      const config: SnackBarConfig = {
-        data: {
-          msg: validationErrors.join(' | '),
-          snackType: SnackType.Error,
-        },
-        duration: 16000,
-      };
-      this.snack.open(config);
+      this.showError(validationErrors.join(' | '), 16000);
       this.applying = false;
       return;
     }
 
-    customResource.metadata!.namespace = this.namespace;
+    const requests: Observable<MWABackendResponse>[] = [];
 
-    this.backend.postInferenceService(customResource).subscribe({
+    for (const svc of inferenceServices) {
+      svc.metadata!.namespace = this.namespace;
+      requests.push(this.backend.postInferenceService(svc));
+    }
+
+    for (const tm of trainedModels) {
+      if (!tm.metadata) {
+        tm.metadata = {};
+      }
+      tm.metadata.namespace = this.namespace;
+      requests.push(this.backend.postTrainedModel(tm));
+    }
+
+    forkJoin(requests).subscribe({
       next: () => {
-        const config: SnackBarConfig = {
-          data: {
-            msg: 'InferenceService created successfully.',
-            snackType: SnackType.Success,
-          },
-          duration: 3000,
-        };
-        this.snack.open(config);
+        const total = inferenceServices.length + trainedModels.length;
+        const msg =
+          total === 1
+            ? 'InferenceService created successfully.'
+            : `${total} resources created successfully.`;
+        this.showSuccess(msg);
         this.applying = false;
         this.navigateBack();
       },
       error: err => {
-        let errorMsg = 'Failed to create InferenceService';
+        let errorMsg = 'Failed to create resources';
 
         if (err?.error?.log) {
           errorMsg = err.error.log;
@@ -148,16 +152,68 @@ export class SubmitFormComponent implements OnInit {
           errorMsg = `Server error: ${err.statusText}`;
         }
 
-        const config: SnackBarConfig = {
-          data: {
-            msg: errorMsg,
-            snackType: SnackType.Error,
-          },
-          duration: 16000,
-        };
-        this.snack.open(config);
+        this.showError(errorMsg, 16000);
         this.applying = false;
       },
     });
+  }
+
+  private validateInferenceService(resource: any): string[] {
+    const errors: string[] = [];
+    if (!resource.apiVersion) {
+      errors.push('InferenceService: Missing required field: apiVersion');
+    }
+    if (!resource.metadata) {
+      errors.push('InferenceService: Missing required field: metadata');
+    } else if (!resource.metadata.name) {
+      errors.push('InferenceService: Missing required field: metadata.name');
+    }
+    if (!resource.spec) {
+      errors.push('InferenceService: Missing required field: spec');
+    } else if (!resource.spec.predictor) {
+      errors.push('InferenceService: Missing required field: spec.predictor');
+    }
+    return errors;
+  }
+
+  private validateTrainedModel(resource: any): string[] {
+    const errors: string[] = [];
+    if (!resource.apiVersion) {
+      errors.push('TrainedModel: Missing required field: apiVersion');
+    }
+    if (!resource.metadata) {
+      errors.push('TrainedModel: Missing required field: metadata');
+    } else if (!resource.metadata.name) {
+      errors.push('TrainedModel: Missing required field: metadata.name');
+    }
+    if (!resource.spec) {
+      errors.push('TrainedModel: Missing required field: spec');
+    } else {
+      if (!resource.spec.inferenceService) {
+        errors.push(
+          'TrainedModel: Missing required field: spec.inferenceService',
+        );
+      }
+      if (!resource.spec.model) {
+        errors.push('TrainedModel: Missing required field: spec.model');
+      }
+    }
+    return errors;
+  }
+
+  private showError(msg: string, duration = 8000) {
+    const config: SnackBarConfig = {
+      data: { msg, snackType: SnackType.Error },
+      duration,
+    };
+    this.snack.open(config);
+  }
+
+  private showSuccess(msg: string) {
+    const config: SnackBarConfig = {
+      data: { msg, snackType: SnackType.Success },
+      duration: 3000,
+    };
+    this.snack.open(config);
   }
 }

--- a/frontend/src/app/services/backend.service.ts
+++ b/frontend/src/app/services/backend.service.ts
@@ -4,7 +4,10 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { InferenceServiceK8s } from '../types/kfserving/v1beta1';
-import { InferenceGraphK8s } from '../types/kfserving/v1alpha1';
+import {
+  InferenceGraphK8s,
+  TrainedModelK8s,
+} from '../types/kfserving/v1alpha1';
 import { MWABackendResponse, InferenceServiceLogs } from '../types/backend';
 import { EventObject } from '../types/event';
 
@@ -253,6 +256,17 @@ export class MWABackendService extends BackendService {
 
     return this.http
       .post<MWABackendResponse>(url, inferenceGraph)
+      .pipe(catchError(error => this.handleError(error)));
+  }
+
+  public postTrainedModel(
+    trainedModel: TrainedModelK8s,
+  ): Observable<MWABackendResponse> {
+    const namespace = trainedModel.metadata!.namespace;
+    const url = `api/namespaces/${namespace}/trainedmodels`;
+
+    return this.http
+      .post<MWABackendResponse>(url, trainedModel)
       .pipe(catchError(error => this.handleError(error)));
   }
 

--- a/frontend/src/app/types/kfserving/v1alpha1.ts
+++ b/frontend/src/app/types/kfserving/v1alpha1.ts
@@ -7,6 +7,20 @@ import {
 } from '@kubernetes/client-node';
 import { Params } from '@angular/router';
 
+export interface TrainedModelSpec {
+  inferenceService: string;
+  model: {
+    framework: string;
+    storageUri: string;
+    memory: string;
+  };
+}
+
+export interface TrainedModelK8s extends K8sObject {
+  metadata?: V1ObjectMeta;
+  spec?: TrainedModelSpec;
+}
+
 export interface InferenceGraphIR extends InferenceGraphK8s {
   // this type is used in the frontend after parsing the backend response
   ui: {


### PR DESCRIPTION
## Description
This PR implements support for multi-document YAML when creating InferenceServices, enabling users to define and deploy InferenceService alongside their associated TrainedModel resources in a single multi-document YAML file and deploy everything in one go.

## Problem
Previously, users could only submit a single InferenceService resource at a time. When using Multi-Model Serving with Triton, this required multiple separate deployments, making it inconvenient to manage related resources together. Users wanted the ability to define everything in a single multi-document YAML file (similar to `kubectl apply -f`) and deploy all resources in one operation.

## Solution

**Technical Implementation:**
- Replaced single-document YAML parsing with multi-document parsing using `loadAll()` to handle multiple K8s resources from a single YAML file
- Implemented resource type routing to validate and segregate InferenceService and TrainedModel documents during parsing
- Added batched resource creation using RxJS `forkJoin()` to deploy all resources in parallel for improved performance
- Introduced granular validation logic for each resource type with specific error messages and field requirements
- Added TrainedModel GVK definition in backend to enable TrainedModel resource creation
- Implemented new API endpoint to handle TrainedModel POST requests
- Refactored notification system with reusable error/success handlers for flexible user feedback
- Enforced business logic: exactly one InferenceService (required) with zero or more TrainedModels (optional)
- Implemented namespace propagation to all resources at deployment time

 **Closes #147**
 
## Usage Example
Users can now create a multi-document YAML:

```yaml
---
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  name: my-model
spec:
  predictor:
    model:
      modelFormat:
        name: triton
      storageUri: gs://bucket/triton-model
---
apiVersion: serving.kserve.io/v1alpha1
kind: TrainedModel
metadata:
  name: model-variant-1
spec:
  inferenceService: my-model
  model:
    framework: triton
    storageUri: gs://bucket/model-variant-1
    memory: "1Gi"
---
apiVersion: serving.kserve.io/v1alpha1
kind: TrainedModel
metadata:
  name: model-variant-2
spec:
  inferenceService: my-model
  model:
    framework: triton
    storageUri: gs://bucket/model-variant-2
    memory: "1Gi"
    
