### PR TITLE
Preserve Kubeflow selector labels in models web app overlay

### DIFF
--- a/.github/workflows/test-manifests.yaml
+++ b/.github/workflows/test-manifests.yaml
@@ -49,6 +49,10 @@ jobs:
         working-directory: kubeflow-manifests
         run: kustomize build common/istio/kubeflow-istio-resources/base | kubectl apply -f -
 
+      - name: Install Profile Controller
+        working-directory: kubeflow-manifests
+        run: ./tests/profile_controller_install.sh
+
       - name: Install Multi-Tenancy
         working-directory: kubeflow-manifests
         run: ./tests/multi_tenancy_install.sh

--- a/manifests/kustomize/overlays/kubeflow/kustomization.yaml
+++ b/manifests/kustomize/overlays/kubeflow/kustomization.yaml
@@ -28,6 +28,12 @@ configurations:
 resources:
   - ../../base
 
+labels:
+  - includeSelectors: true
+    pairs:
+      app: kserve
+      app.kubernetes.io/name: kserve
+
 components:
   - ../../components/istio
 patches:


### PR DESCRIPTION
## Summary
- preserve the Kubeflow `app` and `app.kubernetes.io/name` labels in the models web app Kubeflow overlay selectors
- install the Kubeflow Profile Controller before creating the test `Profile`

## Why
PR #184 applies this repository's Kubeflow overlay after Kubeflow's `kserve_install.sh` has already installed the current models web app. The installed Deployment selector includes the Kubeflow labels, but this overlay did not, so `kubectl apply` tried to mutate `spec.selector` and failed because Deployment selectors are immutable.

After `kubeflow/manifests#3452`, `tests/multi_tenancy_install.sh` no longer installs the Profile Controller or `profiles.kubeflow.org` CRD. The workflow now needs to call `tests/profile_controller_install.sh` before `tests/kubeflow_profile_install.sh` creates the test profile.

## Validation
- `kustomize build manifests/kustomize/overlays/kubeflow`
- `yamllint manifests/kustomize/overlays/kubeflow/kustomization.yaml .github/workflows/test-manifests.yaml`
- `git diff --check`
- compared the rendered Deployment selector against current `kubeflow/manifests` models web app overlay
- GitHub checks are passing on this stacked PR, including `build`

Stacked on #184 to unblock its CI.