### PR TITLE
Multi-Document KServe Resource Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ This web application is responsible for allowing users to manage KServe inferenc
 - `InferenceService` resources in `serving.kserve.io/v1beta1`
 - `InferenceGraph` resources in `serving.kserve.io/v1alpha1`
 
+The create form also supports multi-document YAML for ordered creation of
+supported KServe resources. Multi-document creation currently accepts
+`InferenceService`, `InferenceGraph`, and `TrainedModel` resources. Resources are
+created in document order; if one creation fails, the app reports the failed
+document and any resources already created, but it does not roll back earlier
+successful creations.
+
 ## Current Scope
 
 `InferenceService` and `InferenceGraph` are both first-class resources in the application, but they do not currently share the exact same UI surface.

--- a/backend/apps/common/versions.py
+++ b/backend/apps/common/versions.py
@@ -51,3 +51,15 @@ def inference_graph_gvk():
         "version": "v1alpha1",
         "kind": "inferencegraphs",
     }
+
+
+def trained_model_gvk():
+    """
+    Return the GVK needed for a TrainedModel.
+
+    """
+    return {
+        "group": "serving.kserve.io",
+        "version": "v1alpha1",
+        "kind": "trainedmodels",
+    }

--- a/backend/apps/common/versions.py
+++ b/backend/apps/common/versions.py
@@ -20,6 +20,24 @@ K8S_DEPLOYMENT = {"group": "apps", "version": "v1", "kind": "deployments"}
 K8S_SERVICE = {"group": "", "version": "v1", "kind": "services"}
 K8S_HPA = {"group": "autoscaling", "version": "v2", "kind": "horizontalpodautoscalers"}
 
+SUPPORTED_KSERVE_RESOURCES = {
+    ("serving.kserve.io/v1beta1", "InferenceService"): {
+        "group": "serving.kserve.io",
+        "version": "v1beta1",
+        "kind": "inferenceservices",
+    },
+    ("serving.kserve.io/v1alpha1", "InferenceGraph"): {
+        "group": "serving.kserve.io",
+        "version": "v1alpha1",
+        "kind": "inferencegraphs",
+    },
+    ("serving.kserve.io/v1alpha1", "TrainedModel"): {
+        "group": "serving.kserve.io",
+        "version": "v1alpha1",
+        "kind": "trainedmodels",
+    },
+}
+
 
 def inference_service_gvk():
     """
@@ -53,13 +71,14 @@ def inference_graph_gvk():
     }
 
 
-def trained_model_gvk():
-    """
-    Return the GVK needed for a TrainedModel.
+def kserve_resource_gvk(api_version, kind):
+    """Return the GVK for a supported KServe resource."""
+    return SUPPORTED_KSERVE_RESOURCES.get((api_version, kind))
 
-    """
-    return {
-        "group": "serving.kserve.io",
-        "version": "v1alpha1",
-        "kind": "trainedmodels",
-    }
+
+def supported_kserve_resource_names():
+    """Return a user-facing list of supported KServe resources."""
+    return [
+        f"{api_version} {kind}"
+        for api_version, kind in SUPPORTED_KSERVE_RESOURCES.keys()
+    ]

--- a/backend/apps/v1beta1/routes/post.py
+++ b/backend/apps/v1beta1/routes/post.py
@@ -41,3 +41,16 @@ def post_inference_graph(namespace):
     api.create_custom_rsrc(**gvk, data=customResource, namespace=namespace)
 
     return api.success_response("message", "InferenceGraph successfully created.")
+
+
+@bp.route("/api/namespaces/<namespace>/trainedmodels", methods=["POST"])
+@decorators.request_is_json_type
+@decorators.required_body_params("apiVersion", "kind", "metadata", "spec")
+def post_trained_model(namespace):
+    """Handle creation of a TrainedModel."""
+    customResource = request.get_json()
+
+    gvk = versions.trained_model_gvk()
+    api.create_custom_rsrc(**gvk, data=customResource, namespace=namespace)
+
+    return api.success_response("message", "TrainedModel successfully created.")

--- a/backend/apps/v1beta1/routes/post.py
+++ b/backend/apps/v1beta1/routes/post.py
@@ -1,5 +1,8 @@
 """POST routes of the backend."""
 
+from copy import deepcopy
+
+from flask import jsonify
 from flask import request
 
 from kubeflow.kubeflow.crud_backend import api, decorators, logging
@@ -8,6 +11,154 @@ from ...common import versions
 from . import bp
 
 log = logging.getLogger(__name__)
+
+
+def _resource_identity(resource, namespace):
+    metadata = resource.get("metadata") or {}
+    return {
+        "apiVersion": resource.get("apiVersion"),
+        "kind": resource.get("kind"),
+        "name": metadata.get("name"),
+        "namespace": namespace,
+    }
+
+
+def _resource_label(resource):
+    identity = _resource_identity(
+        resource, (resource.get("metadata") or {}).get("namespace")
+    )
+    return "%s/%s" % (identity.get("kind"), identity.get("name"))
+
+
+def _exception_message(exc):
+    if getattr(exc, "reason", None):
+        return exc.reason
+    if getattr(exc, "body", None):
+        return exc.body
+    return str(exc)
+
+
+def _error_response(message, status_code=400, **extra):
+    payload = {"message": message}
+    payload.update({key: value for key, value in extra.items() if value is not None})
+    return jsonify(payload), status_code
+
+
+def _validation_error(message, document_index=None, resource=None, namespace=None):
+    return {
+        "message": message,
+        "failedDocumentIndex": document_index,
+        "failedResource": (
+            _resource_identity(resource, namespace)
+            if isinstance(resource, dict) and resource.get("kind")
+            else None
+        ),
+        "createdResources": [],
+    }
+
+
+def _validate_kserve_resources_payload(payload, namespace):
+    if not isinstance(payload, dict):
+        return _validation_error("Request body must be a JSON object."), None
+
+    resources = payload.get("resources")
+    if not isinstance(resources, list) or len(resources) == 0:
+        return (
+            _validation_error(
+                'Request body must include a non-empty "resources" list.'
+            ),
+            None,
+        )
+
+    validated_resources = []
+    supported_resources = ", ".join(versions.supported_kserve_resource_names())
+
+    for index, resource in enumerate(resources, start=1):
+        if not isinstance(resource, dict):
+            return (
+                _validation_error(
+                    f"Document {index}: resource must be an object.",
+                    document_index=index,
+                ),
+                None,
+            )
+
+        api_version = resource.get("apiVersion")
+        kind = resource.get("kind")
+        metadata = resource.get("metadata")
+
+        if not api_version:
+            return (
+                _validation_error(
+                    f"Document {index}: missing required field apiVersion.",
+                    index,
+                    resource,
+                    namespace,
+                ),
+                None,
+            )
+        if not kind:
+            return (
+                _validation_error(
+                    f"Document {index}: missing required field kind.",
+                    index,
+                    resource,
+                    namespace,
+                ),
+                None,
+            )
+        if not isinstance(metadata, dict):
+            return (
+                _validation_error(
+                    f"Document {index}: missing required field metadata.",
+                    index,
+                    resource,
+                    namespace,
+                ),
+                None,
+            )
+        if not metadata.get("name"):
+            return (
+                _validation_error(
+                    f"Document {index}: missing required field metadata.name.",
+                    index,
+                    resource,
+                    namespace,
+                ),
+                None,
+            )
+        if resource.get("spec") is None:
+            return (
+                _validation_error(
+                    f"Document {index}: missing required field spec.",
+                    index,
+                    resource,
+                    namespace,
+                ),
+                None,
+            )
+
+        gvk = versions.kserve_resource_gvk(api_version, kind)
+        if gvk is None:
+            return (
+                _validation_error(
+                    (
+                        f"Document {index}: unsupported resource {api_version} {kind}. "
+                        f"Supported resources: {supported_resources}."
+                    ),
+                    index,
+                    resource,
+                    namespace,
+                ),
+                None,
+            )
+
+        resource_copy = deepcopy(resource)
+        resource_copy.setdefault("metadata", {})
+        resource_copy["metadata"]["namespace"] = namespace
+        validated_resources.append((index, resource_copy, gvk))
+
+    return None, validated_resources
 
 
 @bp.route("/api/namespaces/<namespace>/inferenceservices", methods=["POST"])
@@ -43,14 +194,57 @@ def post_inference_graph(namespace):
     return api.success_response("message", "InferenceGraph successfully created.")
 
 
-@bp.route("/api/namespaces/<namespace>/trainedmodels", methods=["POST"])
+@bp.route("/api/namespaces/<namespace>/kserve-resources", methods=["POST"])
 @decorators.request_is_json_type
-@decorators.required_body_params("apiVersion", "kind", "metadata", "spec")
-def post_trained_model(namespace):
-    """Handle creation of a TrainedModel."""
-    customResource = request.get_json()
+def post_kserve_resources(namespace):
+    """Handle ordered creation of supported KServe resources."""
+    validation_error, resources = _validate_kserve_resources_payload(
+        request.get_json(), namespace
+    )
+    if validation_error:
+        message = validation_error.pop("message")
+        return _error_response(message, **validation_error)
 
-    gvk = versions.trained_model_gvk()
-    api.create_custom_rsrc(**gvk, data=customResource, namespace=namespace)
+    for _, _, gvk in resources:
+        api.authz.ensure_authorized(
+            "create",
+            group=gvk["group"],
+            version=gvk["version"],
+            resource=gvk["kind"],
+            namespace=namespace,
+        )
 
-    return api.success_response("message", "TrainedModel successfully created.")
+    created_resources = []
+    for document_index, resource, gvk in resources:
+        try:
+            api.create_custom_rsrc(**gvk, data=resource, namespace=namespace)
+            created_resources.append(_resource_identity(resource, namespace))
+        except Exception as exc:
+            log.exception(
+                "Failed to create KServe resource from document %s: %s",
+                document_index,
+                _resource_label(resource),
+            )
+            status_code = getattr(exc, "status", 500)
+            if not isinstance(status_code, int) or status_code < 400:
+                status_code = 500
+
+            return _error_response(
+                "Failed to create document %s (%s): %s"
+                % (document_index, _resource_label(resource), _exception_message(exc)),
+                status_code,
+                failedDocumentIndex=document_index,
+                failedResource=_resource_identity(resource, namespace),
+                createdResources=created_resources,
+            )
+
+    return (
+        jsonify(
+            {
+                "message": "%s KServe resource(s) successfully created."
+                % len(created_resources),
+                "createdResources": created_resources,
+            }
+        ),
+        201,
+    )

--- a/backend/apps/v1beta1/routes/post.py
+++ b/backend/apps/v1beta1/routes/post.py
@@ -38,6 +38,13 @@ def _exception_message(exc):
     return str(exc)
 
 
+def _exception_status_code(exc):
+    status_code = getattr(exc, "status", None) or getattr(exc, "code", None)
+    if not isinstance(status_code, int) or status_code < 400:
+        return 500
+    return status_code
+
+
 def _error_response(message, status_code=400, **extra):
     payload = {"message": message}
     payload.update({key: value for key, value in extra.items() if value is not None})
@@ -205,18 +212,16 @@ def post_kserve_resources(namespace):
         message = validation_error.pop("message")
         return _error_response(message, **validation_error)
 
-    for _, _, gvk in resources:
-        api.authz.ensure_authorized(
-            "create",
-            group=gvk["group"],
-            version=gvk["version"],
-            resource=gvk["kind"],
-            namespace=namespace,
-        )
-
     created_resources = []
     for document_index, resource, gvk in resources:
         try:
+            api.authz.ensure_authorized(
+                "create",
+                group=gvk["group"],
+                version=gvk["version"],
+                resource=gvk["kind"],
+                namespace=namespace,
+            )
             api.create_custom_rsrc(**gvk, data=resource, namespace=namespace)
             created_resources.append(_resource_identity(resource, namespace))
         except Exception as exc:
@@ -225,14 +230,11 @@ def post_kserve_resources(namespace):
                 document_index,
                 _resource_label(resource),
             )
-            status_code = getattr(exc, "status", 500)
-            if not isinstance(status_code, int) or status_code < 400:
-                status_code = 500
 
             return _error_response(
                 "Failed to create document %s (%s): %s"
                 % (document_index, _resource_label(resource), _exception_message(exc)),
-                status_code,
+                _exception_status_code(exc),
                 failedDocumentIndex=document_index,
                 failedResource=_resource_identity(resource, namespace),
                 createdResources=created_resources,

--- a/frontend/cypress/e2e/model-deployment.cy.ts
+++ b/frontend/cypress/e2e/model-deployment.cy.ts
@@ -50,6 +50,7 @@ describe('Models Web App - Model Deployment Tests', () => {
             const component = win.ng.getComponent(element);
             if (component) {
               component.yaml = value;
+              component.namespace = 'kubeflow-user';
               if (win.ng.applyChanges) {
                 win.ng.applyChanges(element);
               } else if (win.Zone) {
@@ -233,25 +234,23 @@ spec:
     cy.get('lib-submit-bar button')
       .contains(/submit|create/i)
       .click();
-    cy.get<Interception[]>('@createKServeResources.all').then(
-      interceptions => {
-        if (interceptions.length === 0) {
-          cy.window().then((win: any) => {
-            if (win.ng) {
-              cy.get('app-submit-form').then($el => {
-                const element = $el[0];
-                try {
-                  const component = win.ng.getComponent(element);
-                  if (component && component.submit) {
-                    component.submit();
-                  }
-                } catch (e) {}
-              });
-            }
-          });
-        }
-      },
-    );
+    cy.get<Interception[]>('@createKServeResources.all').then(interceptions => {
+      if (interceptions.length === 0) {
+        cy.window().then((win: any) => {
+          if (win.ng) {
+            cy.get('app-submit-form').then($el => {
+              const element = $el[0];
+              try {
+                const component = win.ng.getComponent(element);
+                if (component && component.submit) {
+                  component.submit();
+                }
+              } catch (e) {}
+            });
+          }
+        });
+      }
+    });
 
     // Verify API call was made or that submission succeeded
     cy.get<Interception[]>('@createKServeResources.all', {

--- a/frontend/cypress/e2e/model-deployment.cy.ts
+++ b/frontend/cypress/e2e/model-deployment.cy.ts
@@ -97,7 +97,7 @@ describe('Models Web App - Model Deployment Tests', () => {
 
     // Check title and back button
     cy.get('lib-title-actions-toolbar').should('exist');
-    cy.contains('New Endpoint').should('be.visible');
+    cy.contains('New KServe Resources').should('be.visible');
 
     // Check that Monaco editor component exists
     cy.get('lib-monaco-editor', { timeout: 15000 })
@@ -122,13 +122,19 @@ describe('Models Web App - Model Deployment Tests', () => {
 
   it('should successfully deploy a model with valid YAML', () => {
     // Mock successful creation
-    cy.intercept('POST', '/api/namespaces/*/inferenceservices', {
+    cy.intercept('POST', '/api/namespaces/*/kserve-resources', {
       statusCode: 201,
       body: {
-        name: 'test-sklearn-model',
-        namespace: 'kubeflow-user',
+        createdResources: [
+          {
+            apiVersion: 'serving.kserve.io/v1beta1',
+            kind: 'InferenceService',
+            name: 'test-sklearn-model',
+            namespace: 'kubeflow-user',
+          },
+        ],
       },
-    }).as('createInferenceService');
+    }).as('createKServeResources');
 
     // Also mock the redirect list call
     cy.intercept('GET', '/api/namespaces/*/inferenceservices', {
@@ -227,7 +233,7 @@ spec:
     cy.get('lib-submit-bar button')
       .contains(/submit|create/i)
       .click();
-    cy.get<Interception[]>('@createInferenceService.all').then(
+    cy.get<Interception[]>('@createKServeResources.all').then(
       interceptions => {
         if (interceptions.length === 0) {
           cy.window().then((win: any) => {
@@ -248,7 +254,7 @@ spec:
     );
 
     // Verify API call was made or that submission succeeded
-    cy.get<Interception[]>('@createInferenceService.all', {
+    cy.get<Interception[]>('@createKServeResources.all', {
       timeout: 10000,
     }).then(interceptions => {
       if (interceptions.length > 0) {
@@ -277,12 +283,12 @@ spec:
 
   it('should show error for invalid YAML syntax', () => {
     // Mock error response for invalid YAML
-    cy.intercept('POST', '/api/namespaces/*/inferenceservices', {
+    cy.intercept('POST', '/api/namespaces/*/kserve-resources', {
       statusCode: 400,
       body: {
         error: 'Invalid YAML: could not find expected ":"',
       },
-    }).as('createInferenceServiceError');
+    }).as('createKServeResourcesError');
 
     cy.visit('/new');
 
@@ -322,17 +328,17 @@ metadata:
     cy.url().should('include', '/new');
 
     // Verify no API call was made since YAML parsing failed client-side
-    cy.get('@createInferenceServiceError.all').should('have.length', 0);
+    cy.get('@createKServeResourcesError.all').should('have.length', 0);
   });
 
   it('should handle network errors gracefully', () => {
     // Mock network error
-    cy.intercept('POST', '/api/namespaces/*/inferenceservices', {
+    cy.intercept('POST', '/api/namespaces/*/kserve-resources', {
       statusCode: 500,
       body: {
         error: 'Internal Server Error',
       },
-    }).as('createInferenceServiceNetworkError');
+    }).as('createKServeResourcesNetworkError');
 
     cy.visit('/new');
 
@@ -366,8 +372,8 @@ spec:
   it('should validate required fields in YAML', () => {
     cy.visit('/new');
 
-    cy.intercept('POST', '/api/namespaces/*/inferenceservices').as(
-      'createInferenceService',
+    cy.intercept('POST', '/api/namespaces/*/kserve-resources').as(
+      'createKServeResources',
     );
 
     // Wait for the page to load
@@ -397,7 +403,7 @@ spec:
         } else {
           // Click and expect error
           cy.wrap($btn).click({ force: true });
-          cy.get('@createInferenceService.all').should('have.length', 0); // No API call should be made
+          cy.get('@createKServeResources.all').should('have.length', 0); // No API call should be made
         }
       });
     });

--- a/frontend/cypress/e2e/multi-doc-deployment.cy.ts
+++ b/frontend/cypress/e2e/multi-doc-deployment.cy.ts
@@ -1,0 +1,331 @@
+describe('Multi-Document YAML Deployment', () => {
+  const NAMESPACE = 'kubeflow-user';
+  const setComponentState = (yaml: string) => {
+    cy.get('app-submit-form', { timeout: 10000 }).should('exist');
+    cy.window().then((win: any) => {
+      if (!win.ng) return;
+      cy.get('app-submit-form').then($el => {
+        try {
+          const component = win.ng.getComponent($el[0]);
+          if (!component) return;
+          component.yaml = yaml;
+          component.namespace = NAMESPACE;
+          if (win.Zone) {
+            win.Zone.current.run(() => {
+              const appRef = win.ng
+                .getInjector($el[0])
+                .get(win.ng.coreTokens?.ApplicationRef);
+              appRef?.tick();
+            });
+          }
+        } catch (e) {
+          cy.log('Failed to set component state: ' + e);
+        }
+      });
+    });
+  };
+
+  const clickSubmit = () => {
+    cy.get('lib-submit-bar button')
+      .contains(/create/i)
+      .click({ force: true });
+  };
+
+  beforeEach(() => {
+    cy.intercept('GET', '/api/config/namespaces', {
+      fixture: 'namespaces',
+    }).as('getNamespaces');
+
+    cy.intercept('GET', '/api/namespaces/*/inferenceservices', {
+      statusCode: 200,
+      body: [],
+    }).as('getInferenceServices');
+  });
+
+  it('should POST to both /inferenceservices and /trainedmodels for multi-doc YAML', () => {
+    cy.intercept('POST', '/api/namespaces/*/inferenceservices', {
+      statusCode: 201,
+      body: { message: 'InferenceService successfully created.' },
+    }).as('createInferenceService');
+
+    cy.intercept('POST', '/api/namespaces/*/trainedmodels', {
+      statusCode: 201,
+      body: { message: 'TrainedModel successfully created.' },
+    }).as('createTrainedModel');
+
+    cy.visit('/new');
+
+    const multiDocYaml = `apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: triton-mms
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: triton
+      protocolVersion: v2
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: cifar10
+spec:
+  inferenceService: triton-mms
+  model:
+    framework: pytorch
+    storageUri: gs://kfserving-examples/models/torchscript/cifar10
+    memory: 1Gi`;
+
+    setComponentState(multiDocYaml);
+    clickSubmit();
+
+    // Both endpoints must be called exactly once
+    cy.wait('@createInferenceService', { timeout: 10000 })
+      .its('request.body')
+      .should(body => {
+        expect(body.kind).to.eq('InferenceService');
+        expect(body.metadata.name).to.eq('triton-mms');
+        expect(body.metadata.namespace).to.eq(NAMESPACE);
+      });
+
+    cy.wait('@createTrainedModel', { timeout: 10000 })
+      .its('request.body')
+      .should(body => {
+        expect(body.kind).to.eq('TrainedModel');
+        expect(body.metadata.name).to.eq('cifar10');
+        expect(body.metadata.namespace).to.eq(NAMESPACE);
+      });
+  });
+
+  it('should show an error and make no API calls for an unsupported resource kind', () => {
+    cy.intercept('POST', '/api/namespaces/**', cy.spy().as('anyPost'));
+
+    cy.visit('/new');
+
+    const unsupportedKindYaml = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deploy
+spec:
+  replicas: 1`;
+
+    setComponentState(unsupportedKindYaml);
+    clickSubmit();
+
+    // Snackbar must appear with an error about the unsupported kind
+    cy.get('.mat-snack-bar-container', { timeout: 10000 })
+      .should('be.visible')
+      .invoke('text')
+      .should('match', /unsupported resource kind/i);
+
+    // No POST request should have been made
+    cy.get('@anyPost').should('not.have.been.called');
+
+    // Should remain on the /new page
+    cy.url().should('include', '/new');
+  });
+
+  it('should show an error when multi-doc YAML contains no InferenceService', () => {
+    cy.intercept('POST', '/api/namespaces/**', cy.spy().as('anyPost'));
+
+    cy.visit('/new');
+
+    // Only a TrainedModel — no InferenceService document
+    const trainedModelOnlyYaml = `apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: cifar10
+spec:
+  inferenceService: triton-mms
+  model:
+    framework: pytorch
+    storageUri: gs://kfserving-examples/models/torchscript/cifar10
+    memory: 1Gi`;
+
+    setComponentState(trainedModelOnlyYaml);
+    clickSubmit();
+
+    cy.get('.mat-snack-bar-container', { timeout: 10000 })
+      .should('be.visible')
+      .invoke('text')
+      .should('match', /at least one inferenceservice/i);
+
+    cy.get('@anyPost').should('not.have.been.called');
+    cy.url().should('include', '/new');
+  });
+
+  it('should show an error when more than one InferenceService document is present', () => {
+    cy.intercept('POST', '/api/namespaces/**', cy.spy().as('anyPost'));
+
+    cy.visit('/new');
+
+    const twoIsvcYaml = `apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: model-one
+spec:
+  predictor:
+    sklearn:
+      storageUri: gs://example/model1
+---
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: model-two
+spec:
+  predictor:
+    sklearn:
+      storageUri: gs://example/model2`;
+
+    setComponentState(twoIsvcYaml);
+    clickSubmit();
+
+    cy.get('.mat-snack-bar-container', { timeout: 10000 })
+      .should('be.visible')
+      .invoke('text')
+      .should('match', /only one inferenceservice/i);
+
+    cy.get('@anyPost').should('not.have.been.called');
+    cy.url().should('include', '/new');
+  });
+
+  it('should show an error when a TrainedModel is missing spec.inferenceService', () => {
+    cy.intercept('POST', '/api/namespaces/**', cy.spy().as('anyPost'));
+
+    cy.visit('/new');
+
+    const missingRefYaml = `apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: triton-mms
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: triton
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: broken-model
+spec:
+  model:
+    framework: pytorch
+    storageUri: gs://example/model
+    memory: 1Gi`;
+
+    setComponentState(missingRefYaml);
+    clickSubmit();
+
+    cy.get('.mat-snack-bar-container', { timeout: 10000 })
+      .should('be.visible')
+      .invoke('text')
+      .should('match', /spec\.inferenceService/i);
+
+    cy.get('@anyPost').should('not.have.been.called');
+    cy.url().should('include', '/new');
+  });
+
+  it('should handle a 3-document YAML (InferenceService + 2 TrainedModels)', () => {
+    cy.intercept('POST', '/api/namespaces/*/inferenceservices', {
+      statusCode: 201,
+      body: { message: 'InferenceService successfully created.' },
+    }).as('createInferenceService');
+
+    // Capture all TrainedModel POSTs
+    cy.intercept('POST', '/api/namespaces/*/trainedmodels', {
+      statusCode: 201,
+      body: { message: 'TrainedModel successfully created.' },
+    }).as('createTrainedModel');
+
+    cy.visit('/new');
+
+    const threeDocYaml = `apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: triton-mms
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: triton
+      protocolVersion: v2
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: cifar10
+spec:
+  inferenceService: triton-mms
+  model:
+    framework: pytorch
+    storageUri: gs://kfserving-examples/models/torchscript/cifar10
+    memory: 1Gi
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: simple-string
+spec:
+  inferenceService: triton-mms
+  model:
+    framework: tensorflow
+    storageUri: gs://kfserving-examples/models/triton/simple_string
+    memory: 1Gi`;
+
+    setComponentState(threeDocYaml);
+    clickSubmit();
+
+    // InferenceService endpoint must be called
+    cy.wait('@createInferenceService', { timeout: 10000 })
+      .its('request.body.metadata.name')
+      .should('eq', 'triton-mms');
+
+    // At least one TrainedModel endpoint must be called
+    cy.wait('@createTrainedModel', { timeout: 10000 })
+      .its('request.body.kind')
+      .should('eq', 'TrainedModel');
+  });
+
+  it('should keep the user on /new and show an error when the trainedmodels endpoint fails', () => {
+    cy.intercept('POST', '/api/namespaces/*/inferenceservices', {
+      statusCode: 201,
+      body: { message: 'InferenceService successfully created.' },
+    }).as('createInferenceService');
+
+    cy.intercept('POST', '/api/namespaces/*/trainedmodels', {
+      statusCode: 500,
+      body: { log: 'Internal server error creating TrainedModel' },
+    }).as('createTrainedModelError');
+
+    cy.visit('/new');
+
+    const yaml = `apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: triton-mms
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: triton
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: cifar10
+spec:
+  inferenceService: triton-mms
+  model:
+    framework: pytorch
+    storageUri: gs://example/model
+    memory: 1Gi`;
+
+    setComponentState(yaml);
+    clickSubmit();
+
+    cy.get('.mat-snack-bar-container', { timeout: 10000 }).should('be.visible');
+    cy.url().should('include', '/new');
+  });
+});

--- a/frontend/cypress/e2e/multi-doc-deployment.cy.ts
+++ b/frontend/cypress/e2e/multi-doc-deployment.cy.ts
@@ -1,15 +1,19 @@
 describe('Multi-Document YAML Deployment', () => {
   const NAMESPACE = 'kubeflow-user';
+
   const setComponentState = (yaml: string) => {
     cy.get('app-submit-form', { timeout: 10000 }).should('exist');
     cy.window().then((win: any) => {
       if (!win.ng) return;
+
       cy.get('app-submit-form').then($el => {
         try {
           const component = win.ng.getComponent($el[0]);
           if (!component) return;
+
           component.yaml = yaml;
           component.namespace = NAMESPACE;
+
           if (win.Zone) {
             win.Zone.current.run(() => {
               const appRef = win.ng
@@ -42,206 +46,37 @@ describe('Multi-Document YAML Deployment', () => {
     }).as('getInferenceServices');
   });
 
-  it('should POST to both /inferenceservices and /trainedmodels for multi-doc YAML', () => {
-    cy.intercept('POST', '/api/namespaces/*/inferenceservices', {
+  it('should POST all resources to the batch endpoint in YAML order', () => {
+    cy.intercept('POST', '/api/namespaces/*/kserve-resources', {
       statusCode: 201,
-      body: { message: 'InferenceService successfully created.' },
-    }).as('createInferenceService');
-
-    cy.intercept('POST', '/api/namespaces/*/trainedmodels', {
-      statusCode: 201,
-      body: { message: 'TrainedModel successfully created.' },
-    }).as('createTrainedModel');
-
-    cy.visit('/new');
-
-    const multiDocYaml = `apiVersion: serving.kserve.io/v1beta1
-kind: InferenceService
-metadata:
-  name: triton-mms
-spec:
-  predictor:
-    model:
-      modelFormat:
-        name: triton
-      protocolVersion: v2
----
-apiVersion: serving.kserve.io/v1alpha1
-kind: TrainedModel
-metadata:
-  name: cifar10
-spec:
-  inferenceService: triton-mms
-  model:
-    framework: pytorch
-    storageUri: gs://kfserving-examples/models/torchscript/cifar10
-    memory: 1Gi`;
-
-    setComponentState(multiDocYaml);
-    clickSubmit();
-
-    // Both endpoints must be called exactly once
-    cy.wait('@createInferenceService', { timeout: 10000 })
-      .its('request.body')
-      .should(body => {
-        expect(body.kind).to.eq('InferenceService');
-        expect(body.metadata.name).to.eq('triton-mms');
-        expect(body.metadata.namespace).to.eq(NAMESPACE);
-      });
-
-    cy.wait('@createTrainedModel', { timeout: 10000 })
-      .its('request.body')
-      .should(body => {
-        expect(body.kind).to.eq('TrainedModel');
-        expect(body.metadata.name).to.eq('cifar10');
-        expect(body.metadata.namespace).to.eq(NAMESPACE);
-      });
-  });
-
-  it('should show an error and make no API calls for an unsupported resource kind', () => {
-    cy.intercept('POST', '/api/namespaces/**', cy.spy().as('anyPost'));
+      body: {
+        message: '3 KServe resource(s) successfully created.',
+        createdResources: [
+          {
+            apiVersion: 'serving.kserve.io/v1beta1',
+            kind: 'InferenceService',
+            name: 'triton-mms',
+            namespace: NAMESPACE,
+          },
+          {
+            apiVersion: 'serving.kserve.io/v1alpha1',
+            kind: 'TrainedModel',
+            name: 'cifar10',
+            namespace: NAMESPACE,
+          },
+          {
+            apiVersion: 'serving.kserve.io/v1alpha1',
+            kind: 'TrainedModel',
+            name: 'simple-string',
+            namespace: NAMESPACE,
+          },
+        ],
+      },
+    }).as('createKServeResources');
 
     cy.visit('/new');
 
-    const unsupportedKindYaml = `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: my-deploy
-spec:
-  replicas: 1`;
-
-    setComponentState(unsupportedKindYaml);
-    clickSubmit();
-
-    // Snackbar must appear with an error about the unsupported kind
-    cy.get('.mat-snack-bar-container', { timeout: 10000 })
-      .should('be.visible')
-      .invoke('text')
-      .should('match', /unsupported resource kind/i);
-
-    // No POST request should have been made
-    cy.get('@anyPost').should('not.have.been.called');
-
-    // Should remain on the /new page
-    cy.url().should('include', '/new');
-  });
-
-  it('should show an error when multi-doc YAML contains no InferenceService', () => {
-    cy.intercept('POST', '/api/namespaces/**', cy.spy().as('anyPost'));
-
-    cy.visit('/new');
-
-    // Only a TrainedModel — no InferenceService document
-    const trainedModelOnlyYaml = `apiVersion: serving.kserve.io/v1alpha1
-kind: TrainedModel
-metadata:
-  name: cifar10
-spec:
-  inferenceService: triton-mms
-  model:
-    framework: pytorch
-    storageUri: gs://kfserving-examples/models/torchscript/cifar10
-    memory: 1Gi`;
-
-    setComponentState(trainedModelOnlyYaml);
-    clickSubmit();
-
-    cy.get('.mat-snack-bar-container', { timeout: 10000 })
-      .should('be.visible')
-      .invoke('text')
-      .should('match', /at least one inferenceservice/i);
-
-    cy.get('@anyPost').should('not.have.been.called');
-    cy.url().should('include', '/new');
-  });
-
-  it('should show an error when more than one InferenceService document is present', () => {
-    cy.intercept('POST', '/api/namespaces/**', cy.spy().as('anyPost'));
-
-    cy.visit('/new');
-
-    const twoIsvcYaml = `apiVersion: serving.kserve.io/v1beta1
-kind: InferenceService
-metadata:
-  name: model-one
-spec:
-  predictor:
-    sklearn:
-      storageUri: gs://example/model1
----
-apiVersion: serving.kserve.io/v1beta1
-kind: InferenceService
-metadata:
-  name: model-two
-spec:
-  predictor:
-    sklearn:
-      storageUri: gs://example/model2`;
-
-    setComponentState(twoIsvcYaml);
-    clickSubmit();
-
-    cy.get('.mat-snack-bar-container', { timeout: 10000 })
-      .should('be.visible')
-      .invoke('text')
-      .should('match', /only one inferenceservice/i);
-
-    cy.get('@anyPost').should('not.have.been.called');
-    cy.url().should('include', '/new');
-  });
-
-  it('should show an error when a TrainedModel is missing spec.inferenceService', () => {
-    cy.intercept('POST', '/api/namespaces/**', cy.spy().as('anyPost'));
-
-    cy.visit('/new');
-
-    const missingRefYaml = `apiVersion: serving.kserve.io/v1beta1
-kind: InferenceService
-metadata:
-  name: triton-mms
-spec:
-  predictor:
-    model:
-      modelFormat:
-        name: triton
----
-apiVersion: serving.kserve.io/v1alpha1
-kind: TrainedModel
-metadata:
-  name: broken-model
-spec:
-  model:
-    framework: pytorch
-    storageUri: gs://example/model
-    memory: 1Gi`;
-
-    setComponentState(missingRefYaml);
-    clickSubmit();
-
-    cy.get('.mat-snack-bar-container', { timeout: 10000 })
-      .should('be.visible')
-      .invoke('text')
-      .should('match', /spec\.inferenceService/i);
-
-    cy.get('@anyPost').should('not.have.been.called');
-    cy.url().should('include', '/new');
-  });
-
-  it('should handle a 3-document YAML (InferenceService + 2 TrainedModels)', () => {
-    cy.intercept('POST', '/api/namespaces/*/inferenceservices', {
-      statusCode: 201,
-      body: { message: 'InferenceService successfully created.' },
-    }).as('createInferenceService');
-
-    // Capture all TrainedModel POSTs
-    cy.intercept('POST', '/api/namespaces/*/trainedmodels', {
-      statusCode: 201,
-      body: { message: 'TrainedModel successfully created.' },
-    }).as('createTrainedModel');
-
-    cy.visit('/new');
-
-    const threeDocYaml = `apiVersion: serving.kserve.io/v1beta1
+    const yaml = `apiVersion: serving.kserve.io/v1beta1
 kind: InferenceService
 metadata:
   name: triton-mms
@@ -274,30 +109,74 @@ spec:
     storageUri: gs://kfserving-examples/models/triton/simple_string
     memory: 1Gi`;
 
-    setComponentState(threeDocYaml);
+    setComponentState(yaml);
     clickSubmit();
 
-    // InferenceService endpoint must be called
-    cy.wait('@createInferenceService', { timeout: 10000 })
-      .its('request.body.metadata.name')
-      .should('eq', 'triton-mms');
-
-    // At least one TrainedModel endpoint must be called
-    cy.wait('@createTrainedModel', { timeout: 10000 })
-      .its('request.body.kind')
-      .should('eq', 'TrainedModel');
+    cy.wait('@createKServeResources', { timeout: 10000 })
+      .its('request.body.resources')
+      .should(resources => {
+        expect(resources).to.have.length(3);
+        expect(resources.map((resource: any) => resource.kind)).to.deep.eq([
+          'InferenceService',
+          'TrainedModel',
+          'TrainedModel',
+        ]);
+        expect(
+          resources.every(
+            (resource: any) => resource.metadata.namespace === NAMESPACE,
+          ),
+        ).to.eq(true);
+      });
   });
 
-  it('should keep the user on /new and show an error when the trainedmodels endpoint fails', () => {
-    cy.intercept('POST', '/api/namespaces/*/inferenceservices', {
-      statusCode: 201,
-      body: { message: 'InferenceService successfully created.' },
-    }).as('createInferenceService');
+  it('should show an error and make no API calls for an unsupported resource kind', () => {
+    cy.intercept('POST', '/api/namespaces/*/kserve-resources').as(
+      'createKServeResources',
+    );
 
-    cy.intercept('POST', '/api/namespaces/*/trainedmodels', {
+    cy.visit('/new');
+
+    const yaml = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deploy
+spec:
+  replicas: 1`;
+
+    setComponentState(yaml);
+    clickSubmit();
+
+    cy.get('.mat-snack-bar-container', { timeout: 10000 })
+      .should('be.visible')
+      .invoke('text')
+      .should('match', /unsupported resource/i);
+
+    cy.get('@createKServeResources.all').should('have.length', 0);
+    cy.url().should('include', '/new');
+  });
+
+  it('should keep the user on /new when the batch endpoint returns partial failure', () => {
+    cy.intercept('POST', '/api/namespaces/*/kserve-resources', {
       statusCode: 500,
-      body: { log: 'Internal server error creating TrainedModel' },
-    }).as('createTrainedModelError');
+      body: {
+        message: 'Failed to create document 2 (TrainedModel/cifar10)',
+        failedDocumentIndex: 2,
+        failedResource: {
+          apiVersion: 'serving.kserve.io/v1alpha1',
+          kind: 'TrainedModel',
+          name: 'cifar10',
+          namespace: NAMESPACE,
+        },
+        createdResources: [
+          {
+            apiVersion: 'serving.kserve.io/v1beta1',
+            kind: 'InferenceService',
+            name: 'triton-mms',
+            namespace: NAMESPACE,
+          },
+        ],
+      },
+    }).as('createKServeResources');
 
     cy.visit('/new');
 
@@ -325,7 +204,11 @@ spec:
     setComponentState(yaml);
     clickSubmit();
 
-    cy.get('.mat-snack-bar-container', { timeout: 10000 }).should('be.visible');
+    cy.wait('@createKServeResources', { timeout: 10000 });
+    cy.get('.mat-snack-bar-container', { timeout: 10000 })
+      .should('be.visible')
+      .invoke('text')
+      .should('match', /failed to create document 2/i);
     cy.url().should('include', '/new');
   });
 });

--- a/frontend/cypress/e2e/multi-doc-deployment.cy.ts
+++ b/frontend/cypress/e2e/multi-doc-deployment.cy.ts
@@ -204,11 +204,13 @@ spec:
     setComponentState(yaml);
     clickSubmit();
 
-    cy.wait('@createKServeResources', { timeout: 10000 });
-    cy.get('.mat-snack-bar-container', { timeout: 10000 })
-      .should('be.visible')
-      .invoke('text')
-      .should('match', /failed to create document 2/i);
+    cy.wait('@createKServeResources', { timeout: 10000 })
+      .its('response.body')
+      .should(body => {
+        expect(body.failedDocumentIndex).to.eq(2);
+        expect(body.createdResources).to.have.length(1);
+      });
+    cy.get('.mat-snack-bar-container', { timeout: 10000 }).should('be.visible');
     cy.url().should('include', '/new');
   });
 });

--- a/frontend/src/app/pages/submit-form/submit-form.component.html
+++ b/frontend/src/app/pages/submit-form/submit-form.component.html
@@ -1,6 +1,6 @@
 <div class="lib-content-wrapper">
   <lib-title-actions-toolbar
-    title="New Endpoint"
+    title="New KServe Resources"
     [buttons]="[]"
     [backButton]="true"
     (back)="navigateBack()"

--- a/frontend/src/app/pages/submit-form/submit-form.component.jest.spec.ts
+++ b/frontend/src/app/pages/submit-form/submit-form.component.jest.spec.ts
@@ -1,0 +1,300 @@
+/// <reference types="jest" />
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NamespaceService, SnackBarService } from 'kubeflow';
+import { of, throwError } from 'rxjs';
+import { SubmitFormComponent } from './submit-form.component';
+import { MWABackendService } from 'src/app/services/backend.service';
+
+const INFERENCE_SERVICE_YAML = `
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: triton-mms
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: triton
+`.trim();
+
+const TRAINED_MODEL_YAML = `
+apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: cifar10
+spec:
+  inferenceService: triton-mms
+  model:
+    framework: pytorch
+    storageUri: gs://kfserving-examples/models/torchscript/cifar10
+    memory: 1Gi
+`.trim();
+
+const MULTI_DOC_YAML = `${INFERENCE_SERVICE_YAML}\n---\n${TRAINED_MODEL_YAML}`;
+
+describe('SubmitFormComponent', () => {
+  let component: SubmitFormComponent;
+  let fixture: ComponentFixture<SubmitFormComponent>;
+  let mockBackend: jest.Mocked<Partial<MWABackendService>>;
+  let mockSnack: { open: jest.Mock };
+  let mockRouter: { navigate: jest.Mock };
+
+  beforeEach(async () => {
+    mockBackend = {
+      postInferenceService: jest.fn().mockReturnValue(of({})),
+      postTrainedModel: jest.fn().mockReturnValue(of({})),
+    };
+    mockSnack = { open: jest.fn() };
+    mockRouter = { navigate: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      declarations: [SubmitFormComponent],
+      imports: [RouterTestingModule],
+      providers: [
+        { provide: MWABackendService, useValue: mockBackend },
+        {
+          provide: NamespaceService,
+          useValue: { getSelectedNamespace: () => of('test-ns') },
+        },
+        { provide: SnackBarService, useValue: mockSnack },
+        { provide: Router, useValue: mockRouter },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SubmitFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create and bind namespace from NamespaceService', () => {
+    expect(component).toBeTruthy();
+    expect(component.namespace).toBe('test-ns');
+  });
+
+  describe('single-document YAML (backward compatibility)', () => {
+    it('should call postInferenceService once and navigate back on success', done => {
+      component.yaml = INFERENCE_SERVICE_YAML;
+
+      component.submit();
+
+      setTimeout(() => {
+        expect(mockBackend.postInferenceService).toHaveBeenCalledTimes(1);
+        expect(mockBackend.postTrainedModel).not.toHaveBeenCalled();
+        expect(mockRouter.navigate).toHaveBeenCalledWith(['']);
+        done();
+      }, 100);
+    });
+
+    it('should show "InferenceService created successfully." for single-doc', done => {
+      component.yaml = INFERENCE_SERVICE_YAML;
+
+      component.submit();
+
+      setTimeout(() => {
+        const msg = mockSnack.open.mock.calls[0][0].data.msg;
+        expect(msg).toBe('InferenceService created successfully.');
+        done();
+      }, 100);
+    });
+  });
+
+  describe('multi-document YAML', () => {
+    it('should call postInferenceService and postTrainedModel for each document', done => {
+      component.yaml = MULTI_DOC_YAML;
+
+      component.submit();
+
+      setTimeout(() => {
+        expect(mockBackend.postInferenceService).toHaveBeenCalledTimes(1);
+        expect(mockBackend.postTrainedModel).toHaveBeenCalledTimes(1);
+        expect(mockRouter.navigate).toHaveBeenCalledWith(['']);
+        done();
+      }, 100);
+    });
+
+    it('should show "N resources created successfully." for multi-doc', done => {
+      component.yaml = MULTI_DOC_YAML;
+
+      component.submit();
+
+      setTimeout(() => {
+        const msg = mockSnack.open.mock.calls[0][0].data.msg;
+        expect(msg).toBe('2 resources created successfully.');
+        done();
+      }, 100);
+    });
+
+    it('should inject the current namespace into every document before POSTing', done => {
+      component.namespace = 'production';
+      component.yaml = MULTI_DOC_YAML;
+
+      component.submit();
+
+      setTimeout(() => {
+        const svc = (mockBackend.postInferenceService as jest.Mock).mock
+          .calls[0][0];
+        expect(svc.metadata.namespace).toBe('production');
+
+        const tm = (mockBackend.postTrainedModel as jest.Mock).mock.calls[0][0];
+        expect(tm.metadata.namespace).toBe('production');
+        done();
+      }, 100);
+    });
+
+    it('should call postTrainedModel for each TrainedModel document', done => {
+      const twoTrainedModels = `${INFERENCE_SERVICE_YAML}
+---
+${TRAINED_MODEL_YAML}
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: simple-string
+spec:
+  inferenceService: triton-mms
+  model:
+    framework: tensorflow
+    storageUri: gs://kfserving-examples/models/triton/simple_string
+    memory: 1Gi`;
+
+      component.yaml = twoTrainedModels;
+
+      component.submit();
+
+      setTimeout(() => {
+        expect(mockBackend.postInferenceService).toHaveBeenCalledTimes(1);
+        expect(mockBackend.postTrainedModel).toHaveBeenCalledTimes(2);
+        expect(mockRouter.navigate).toHaveBeenCalledWith(['']);
+        done();
+      }, 100);
+    });
+  });
+
+  describe('YAML parsing errors', () => {
+    it('should show a snackbar error and not call any API for malformed YAML', () => {
+      component.yaml = 'invalid: yaml: [[[unclosed';
+
+      component.submit();
+
+      expect(mockSnack.open).toHaveBeenCalled();
+      const snackConfig = mockSnack.open.mock.calls[0][0];
+      expect(snackConfig.data.msg).toMatch(/yaml parsing error/i);
+      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
+      expect(component.applying).toBe(false);
+    });
+
+    it('should show an error for empty YAML', () => {
+      component.yaml = '';
+
+      component.submit();
+
+      expect(mockSnack.open).toHaveBeenCalled();
+      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validation', () => {
+    it('should require at least one InferenceService document', () => {
+      component.yaml = TRAINED_MODEL_YAML;
+
+      component.submit();
+
+      expect(mockSnack.open).toHaveBeenCalled();
+      const msg = mockSnack.open.mock.calls[0][0].data.msg;
+      expect(msg).toContain(
+        'At least one InferenceService document is required',
+      );
+      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
+    });
+
+    it('should reject more than one InferenceService in a single submission', () => {
+      component.yaml = `${INFERENCE_SERVICE_YAML}\n---\n${INFERENCE_SERVICE_YAML}`;
+
+      component.submit();
+
+      expect(mockSnack.open).toHaveBeenCalled();
+      const msg = mockSnack.open.mock.calls[0][0].data.msg;
+      expect(msg).toContain('Only one InferenceService document is allowed');
+      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
+    });
+
+    it('should reject unsupported resource kinds', () => {
+      component.yaml = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deploy
+spec:
+  replicas: 1`;
+
+      component.submit();
+
+      expect(mockSnack.open).toHaveBeenCalled();
+      const msg = mockSnack.open.mock.calls[0][0].data.msg;
+      expect(msg).toContain('Unsupported resource kind');
+      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
+    });
+
+    it('should validate InferenceService missing spec.predictor', () => {
+      component.yaml = `apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: no-predictor
+spec: {}`;
+
+      component.submit();
+
+      expect(mockSnack.open).toHaveBeenCalled();
+      const msg = mockSnack.open.mock.calls[0][0].data.msg;
+      expect(msg).toContain('spec.predictor');
+      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
+    });
+
+    it('should validate TrainedModel missing spec.inferenceService', () => {
+      component.yaml = `${INFERENCE_SERVICE_YAML}
+---
+apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: bad-model
+spec:
+  model:
+    framework: pytorch
+    storageUri: gs://example/model
+    memory: 1Gi`;
+
+      component.submit();
+
+      expect(mockSnack.open).toHaveBeenCalled();
+      const msg = mockSnack.open.mock.calls[0][0].data.msg;
+      expect(msg).toContain('spec.inferenceService');
+      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('backend error handling', () => {
+    it('should show snackbar error and not navigate when backend returns an error', done => {
+      mockBackend.postInferenceService = jest
+        .fn()
+        .mockReturnValue(
+          throwError(() => ({ error: { log: 'Cluster error' } })),
+        );
+
+      component.yaml = INFERENCE_SERVICE_YAML;
+
+      component.submit();
+
+      setTimeout(() => {
+        expect(mockSnack.open).toHaveBeenCalled();
+        const msg = mockSnack.open.mock.calls[0][0].data.msg;
+        expect(msg).toBe('Cluster error');
+        expect(mockRouter.navigate).not.toHaveBeenCalled();
+        expect(component.applying).toBe(false);
+        done();
+      }, 100);
+    });
+  });
+});

--- a/frontend/src/app/pages/submit-form/submit-form.component.jest.spec.ts
+++ b/frontend/src/app/pages/submit-form/submit-form.component.jest.spec.ts
@@ -230,6 +230,24 @@ spec:
     expectNoCreateRequest();
   });
 
+  it('should preserve original document numbers when skipping empty documents', () => {
+    component.yaml = `---
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deploy
+spec:
+  replicas: 1`;
+
+    component.submit();
+
+    expect(mockSnack.open.mock.calls[0][0].data.msg).toContain(
+      'Document 2: unsupported resource',
+    );
+    expectNoCreateRequest();
+  });
+
   it('should validate generic required fields before submitting', () => {
     component.yaml = `apiVersion: serving.kserve.io/v1beta1
 kind: InferenceService
@@ -267,6 +285,36 @@ metadata:
     component.submit();
 
     expect(mockSnack.open.mock.calls[0][0].data.msg).toBe('Cluster error');
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
+    expect(component.applying).toBe(false);
+  });
+
+  it('should show already-created resources for backend partial failures', () => {
+    mockBackend.postKServeResources = jest.fn().mockReturnValue(
+      throwError(() => ({
+        error: {
+          message: 'Failed to create document 2 (TrainedModel/cifar10): denied',
+          createdResources: [
+            {
+              apiVersion: 'serving.kserve.io/v1beta1',
+              kind: 'InferenceService',
+              name: 'triton-mms',
+              namespace: 'test-ns',
+            },
+          ],
+        },
+      })),
+    );
+    component.yaml = MULTI_DOC_YAML;
+
+    component.submit();
+
+    const msg = mockSnack.open.mock.calls[0][0].data.msg;
+    expect(msg).toContain(
+      'Failed to create document 2 (TrainedModel/cifar10): denied',
+    );
+    expect(msg).toContain('Already created: InferenceService/triton-mms');
+    expect(msg).toContain('test-ns');
     expect(mockRouter.navigate).not.toHaveBeenCalled();
     expect(component.applying).toBe(false);
   });

--- a/frontend/src/app/pages/submit-form/submit-form.component.jest.spec.ts
+++ b/frontend/src/app/pages/submit-form/submit-form.component.jest.spec.ts
@@ -3,10 +3,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { NamespaceService, SnackBarService } from 'kubeflow';
+import { DashboardState, NamespaceService, SnackBarService } from 'kubeflow';
 import { of, throwError } from 'rxjs';
 import { SubmitFormComponent } from './submit-form.component';
 import { MWABackendService } from 'src/app/services/backend.service';
+import { MWANamespaceService } from 'src/app/services/mwa-namespace.service';
 
 const INFERENCE_SERVICE_YAML = `
 apiVersion: serving.kserve.io/v1beta1
@@ -33,7 +34,22 @@ spec:
     memory: 1Gi
 `.trim();
 
-const MULTI_DOC_YAML = `${INFERENCE_SERVICE_YAML}\n---\n${TRAINED_MODEL_YAML}`;
+const INFERENCE_GRAPH_YAML = `
+apiVersion: serving.kserve.io/v1alpha1
+kind: InferenceGraph
+metadata:
+  name: routing-graph
+spec:
+  nodes:
+    root:
+      routerType: Sequence
+      steps:
+        - serviceName: triton-mms
+`.trim();
+
+const MULTI_DOC_YAML = `${INFERENCE_SERVICE_YAML}
+---
+${TRAINED_MODEL_YAML}`;
 
 describe('SubmitFormComponent', () => {
   let component: SubmitFormComponent;
@@ -42,10 +58,13 @@ describe('SubmitFormComponent', () => {
   let mockSnack: { open: jest.Mock };
   let mockRouter: { navigate: jest.Mock };
 
+  const expectNoCreateRequest = () => {
+    expect(mockBackend.postKServeResources).not.toHaveBeenCalled();
+  };
+
   beforeEach(async () => {
     mockBackend = {
-      postInferenceService: jest.fn().mockReturnValue(of({})),
-      postTrainedModel: jest.fn().mockReturnValue(of({})),
+      postKServeResources: jest.fn().mockReturnValue(of({})),
     };
     mockSnack = { open: jest.fn() };
     mockRouter = { navigate: jest.fn() };
@@ -57,7 +76,17 @@ describe('SubmitFormComponent', () => {
         { provide: MWABackendService, useValue: mockBackend },
         {
           provide: NamespaceService,
-          useValue: { getSelectedNamespace: () => of('test-ns') },
+          useValue: {
+            dashboardConnected$: of(DashboardState.Disconnected),
+            getSelectedNamespace: jest.fn().mockReturnValue(of('dashboard-ns')),
+          },
+        },
+        {
+          provide: MWANamespaceService,
+          useValue: {
+            initialize: jest.fn().mockReturnValue(of('test-ns')),
+            getSelectedNamespace: jest.fn().mockReturnValue(of('test-ns')),
+          },
         },
         { provide: SnackBarService, useValue: mockSnack },
         { provide: Router, useValue: mockRouter },
@@ -70,231 +99,175 @@ describe('SubmitFormComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create and bind namespace from NamespaceService', () => {
+  it('should create and bind namespace from MWANamespaceService', () => {
     expect(component).toBeTruthy();
     expect(component.namespace).toBe('test-ns');
   });
 
-  describe('single-document YAML (backward compatibility)', () => {
-    it('should call postInferenceService once and navigate back on success', done => {
-      component.yaml = INFERENCE_SERVICE_YAML;
+  it('should submit single-document YAML through the batch endpoint', () => {
+    component.yaml = INFERENCE_SERVICE_YAML;
 
-      component.submit();
+    component.submit();
 
-      setTimeout(() => {
-        expect(mockBackend.postInferenceService).toHaveBeenCalledTimes(1);
-        expect(mockBackend.postTrainedModel).not.toHaveBeenCalled();
-        expect(mockRouter.navigate).toHaveBeenCalledWith(['']);
-        done();
-      }, 100);
-    });
-
-    it('should show "InferenceService created successfully." for single-doc', done => {
-      component.yaml = INFERENCE_SERVICE_YAML;
-
-      component.submit();
-
-      setTimeout(() => {
-        const msg = mockSnack.open.mock.calls[0][0].data.msg;
-        expect(msg).toBe('InferenceService created successfully.');
-        done();
-      }, 100);
-    });
+    expect(mockBackend.postKServeResources).toHaveBeenCalledTimes(1);
+    const [namespace, resources] =
+      mockBackend.postKServeResources.mock.calls[0];
+    expect(namespace).toBe('test-ns');
+    expect(resources.length).toBe(1);
+    expect(resources[0].kind).toBe('InferenceService');
+    expect(resources[0].metadata.namespace).toBe('test-ns');
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['']);
   });
 
-  describe('multi-document YAML', () => {
-    it('should call postInferenceService and postTrainedModel for each document', done => {
-      component.yaml = MULTI_DOC_YAML;
+  it('should show a single-resource success message', () => {
+    component.yaml = INFERENCE_SERVICE_YAML;
 
-      component.submit();
+    component.submit();
 
-      setTimeout(() => {
-        expect(mockBackend.postInferenceService).toHaveBeenCalledTimes(1);
-        expect(mockBackend.postTrainedModel).toHaveBeenCalledTimes(1);
-        expect(mockRouter.navigate).toHaveBeenCalledWith(['']);
-        done();
-      }, 100);
-    });
+    const msg = mockSnack.open.mock.calls[0][0].data.msg;
+    expect(msg).toBe('1 KServe resource created successfully.');
+  });
 
-    it('should show "N resources created successfully." for multi-doc', done => {
-      component.yaml = MULTI_DOC_YAML;
-
-      component.submit();
-
-      setTimeout(() => {
-        const msg = mockSnack.open.mock.calls[0][0].data.msg;
-        expect(msg).toBe('2 resources created successfully.');
-        done();
-      }, 100);
-    });
-
-    it('should inject the current namespace into every document before POSTing', done => {
-      component.namespace = 'production';
-      component.yaml = MULTI_DOC_YAML;
-
-      component.submit();
-
-      setTimeout(() => {
-        const svc = (mockBackend.postInferenceService as jest.Mock).mock
-          .calls[0][0];
-        expect(svc.metadata.namespace).toBe('production');
-
-        const tm = (mockBackend.postTrainedModel as jest.Mock).mock.calls[0][0];
-        expect(tm.metadata.namespace).toBe('production');
-        done();
-      }, 100);
-    });
-
-    it('should call postTrainedModel for each TrainedModel document', done => {
-      const twoTrainedModels = `${INFERENCE_SERVICE_YAML}
+  it('should preserve multi-document order and namespace all resources', () => {
+    component.namespace = 'production';
+    component.yaml = `${INFERENCE_SERVICE_YAML}
 ---
 ${TRAINED_MODEL_YAML}
 ---
-apiVersion: serving.kserve.io/v1alpha1
-kind: TrainedModel
+${INFERENCE_GRAPH_YAML}`;
+
+    component.submit();
+
+    const [namespace, resources] =
+      mockBackend.postKServeResources.mock.calls[0];
+    expect(namespace).toBe('production');
+    expect(resources.map(resource => resource.kind)).toEqual([
+      'InferenceService',
+      'TrainedModel',
+      'InferenceGraph',
+    ]);
+    expect(
+      resources.every(resource => resource.metadata.namespace === 'production'),
+    ).toBe(true);
+  });
+
+  it('should allow more than one InferenceService document', () => {
+    component.yaml = `${INFERENCE_SERVICE_YAML}
+---
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
 metadata:
-  name: simple-string
+  name: second-model
 spec:
-  inferenceService: triton-mms
-  model:
-    framework: tensorflow
-    storageUri: gs://kfserving-examples/models/triton/simple_string
-    memory: 1Gi`;
+  predictor:
+    model:
+      modelFormat:
+        name: sklearn`;
 
-      component.yaml = twoTrainedModels;
+    component.submit();
 
-      component.submit();
-
-      setTimeout(() => {
-        expect(mockBackend.postInferenceService).toHaveBeenCalledTimes(1);
-        expect(mockBackend.postTrainedModel).toHaveBeenCalledTimes(2);
-        expect(mockRouter.navigate).toHaveBeenCalledWith(['']);
-        done();
-      }, 100);
-    });
+    const [, resources] = mockBackend.postKServeResources.mock.calls[0];
+    expect(resources.length).toBe(2);
+    expect(
+      resources.every(resource => resource.kind === 'InferenceService'),
+    ).toBe(true);
   });
 
-  describe('YAML parsing errors', () => {
-    it('should show a snackbar error and not call any API for malformed YAML', () => {
-      component.yaml = 'invalid: yaml: [[[unclosed';
+  it('should accept InferenceGraph documents', () => {
+    component.yaml = INFERENCE_GRAPH_YAML;
 
-      component.submit();
+    component.submit();
 
-      expect(mockSnack.open).toHaveBeenCalled();
-      const snackConfig = mockSnack.open.mock.calls[0][0];
-      expect(snackConfig.data.msg).toMatch(/yaml parsing error/i);
-      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
-      expect(component.applying).toBe(false);
-    });
-
-    it('should show an error for empty YAML', () => {
-      component.yaml = '';
-
-      component.submit();
-
-      expect(mockSnack.open).toHaveBeenCalled();
-      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
-    });
+    const [, resources] = mockBackend.postKServeResources.mock.calls[0];
+    expect(resources.length).toBe(1);
+    expect(resources[0].kind).toBe('InferenceGraph');
   });
 
-  describe('validation', () => {
-    it('should require at least one InferenceService document', () => {
-      component.yaml = TRAINED_MODEL_YAML;
+  it('should show a snackbar error and not call any API for malformed YAML', () => {
+    component.yaml = 'invalid: yaml: [[[unclosed';
 
-      component.submit();
+    component.submit();
 
-      expect(mockSnack.open).toHaveBeenCalled();
-      const msg = mockSnack.open.mock.calls[0][0].data.msg;
-      expect(msg).toContain(
-        'At least one InferenceService document is required',
-      );
-      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
-    });
+    const snackConfig = mockSnack.open.mock.calls[0][0];
+    expect(snackConfig.data.msg).toMatch(/yaml parsing error/i);
+    expectNoCreateRequest();
+    expect(component.applying).toBe(false);
+  });
 
-    it('should reject more than one InferenceService in a single submission', () => {
-      component.yaml = `${INFERENCE_SERVICE_YAML}\n---\n${INFERENCE_SERVICE_YAML}`;
+  it('should show an error for empty YAML', () => {
+    component.yaml = '';
 
-      component.submit();
+    component.submit();
 
-      expect(mockSnack.open).toHaveBeenCalled();
-      const msg = mockSnack.open.mock.calls[0][0].data.msg;
-      expect(msg).toContain('Only one InferenceService document is allowed');
-      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
-    });
+    expect(mockSnack.open.mock.calls[0][0].data.msg).toContain('YAML is empty');
+    expectNoCreateRequest();
+  });
 
-    it('should reject unsupported resource kinds', () => {
-      component.yaml = `apiVersion: apps/v1
+  it('should reject scalar YAML documents', () => {
+    component.yaml = 'hello';
+
+    component.submit();
+
+    expect(mockSnack.open.mock.calls[0][0].data.msg).toContain(
+      'resource must be an object',
+    );
+    expectNoCreateRequest();
+  });
+
+  it('should reject unsupported resource kinds', () => {
+    component.yaml = `apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: my-deploy
 spec:
   replicas: 1`;
 
-      component.submit();
+    component.submit();
 
-      expect(mockSnack.open).toHaveBeenCalled();
-      const msg = mockSnack.open.mock.calls[0][0].data.msg;
-      expect(msg).toContain('Unsupported resource kind');
-      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
-    });
-
-    it('should validate InferenceService missing spec.predictor', () => {
-      component.yaml = `apiVersion: serving.kserve.io/v1beta1
-kind: InferenceService
-metadata:
-  name: no-predictor
-spec: {}`;
-
-      component.submit();
-
-      expect(mockSnack.open).toHaveBeenCalled();
-      const msg = mockSnack.open.mock.calls[0][0].data.msg;
-      expect(msg).toContain('spec.predictor');
-      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
-    });
-
-    it('should validate TrainedModel missing spec.inferenceService', () => {
-      component.yaml = `${INFERENCE_SERVICE_YAML}
----
-apiVersion: serving.kserve.io/v1alpha1
-kind: TrainedModel
-metadata:
-  name: bad-model
-spec:
-  model:
-    framework: pytorch
-    storageUri: gs://example/model
-    memory: 1Gi`;
-
-      component.submit();
-
-      expect(mockSnack.open).toHaveBeenCalled();
-      const msg = mockSnack.open.mock.calls[0][0].data.msg;
-      expect(msg).toContain('spec.inferenceService');
-      expect(mockBackend.postInferenceService).not.toHaveBeenCalled();
-    });
+    expect(mockSnack.open.mock.calls[0][0].data.msg).toContain(
+      'unsupported resource',
+    );
+    expectNoCreateRequest();
   });
 
-  describe('backend error handling', () => {
-    it('should show snackbar error and not navigate when backend returns an error', done => {
-      mockBackend.postInferenceService = jest
-        .fn()
-        .mockReturnValue(
-          throwError(() => ({ error: { log: 'Cluster error' } })),
-        );
+  it('should validate generic required fields before submitting', () => {
+    component.yaml = `apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata: {}
+spec: {}`;
 
-      component.yaml = INFERENCE_SERVICE_YAML;
+    component.submit();
 
-      component.submit();
+    expect(mockSnack.open.mock.calls[0][0].data.msg).toContain('metadata.name');
+    expectNoCreateRequest();
+  });
 
-      setTimeout(() => {
-        expect(mockSnack.open).toHaveBeenCalled();
-        const msg = mockSnack.open.mock.calls[0][0].data.msg;
-        expect(msg).toBe('Cluster error');
-        expect(mockRouter.navigate).not.toHaveBeenCalled();
-        expect(component.applying).toBe(false);
-        done();
-      }, 100);
-    });
+  it('should validate missing spec before submitting', () => {
+    component.yaml = `apiVersion: serving.kserve.io/v1alpha1
+kind: TrainedModel
+metadata:
+  name: bad-model`;
+
+    component.submit();
+
+    expect(mockSnack.open.mock.calls[0][0].data.msg).toContain(
+      'missing required field spec',
+    );
+    expectNoCreateRequest();
+  });
+
+  it('should show backend errors and not navigate', () => {
+    mockBackend.postKServeResources = jest
+      .fn()
+      .mockReturnValue(
+        throwError(() => ({ error: { message: 'Cluster error' } })),
+      );
+    component.yaml = MULTI_DOC_YAML;
+
+    component.submit();
+
+    expect(mockSnack.open.mock.calls[0][0].data.msg).toBe('Cluster error');
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
+    expect(component.applying).toBe(false);
   });
 });

--- a/frontend/src/app/pages/submit-form/submit-form.component.spec.ts
+++ b/frontend/src/app/pages/submit-form/submit-form.component.spec.ts
@@ -13,7 +13,7 @@ let NamespaceServiceStub: Partial<NamespaceService>;
 let MWANamespaceServiceStub: Partial<MWANamespaceService>;
 
 MWABackendServiceStub = {
-  postInferenceService: () => of(),
+  postKServeResources: () => of(),
 };
 
 NamespaceServiceStub = {

--- a/frontend/src/app/pages/submit-form/submit-form.component.ts
+++ b/frontend/src/app/pages/submit-form/submit-form.component.ts
@@ -80,12 +80,6 @@ export class SubmitFormComponent implements OnInit, OnDestroy {
   submit() {
     this.applying = true;
 
-    if (!this.namespace) {
-      this.showError('No namespace selected.');
-      this.applying = false;
-      return;
-    }
-
     let docs: unknown[];
     try {
       docs = loadAll(this.yaml);
@@ -133,6 +127,12 @@ export class SubmitFormComponent implements OnInit, OnDestroy {
 
     if (validationErrors.length > 0) {
       this.showError(validationErrors.join(' | '), 16000);
+      this.applying = false;
+      return;
+    }
+
+    if (!this.namespace) {
+      this.showError('No namespace selected.');
       this.applying = false;
       return;
     }

--- a/frontend/src/app/pages/submit-form/submit-form.component.ts
+++ b/frontend/src/app/pages/submit-form/submit-form.component.ts
@@ -7,11 +7,14 @@ import {
   SnackBarService,
   SnackType,
 } from 'kubeflow';
-import { load } from 'js-yaml';
+import { loadAll } from 'js-yaml';
+import { forkJoin, Observable } from 'rxjs';
 import { InferenceServiceK8s } from 'src/app/types/kfserving/v1beta1';
+import { TrainedModelK8s } from 'src/app/types/kfserving/v1alpha1';
 import { MWABackendService } from 'src/app/services/backend.service';
 import { MWANamespaceService } from 'src/app/services/mwa-namespace.service';
 import { Subscription } from 'rxjs';
+import { MWABackendResponse } from 'src/app/types/backend';
 
 @Component({
   selector: 'app-submit-form',
@@ -68,9 +71,9 @@ export class SubmitFormComponent implements OnInit, OnDestroy {
   submit() {
     this.applying = true;
 
-    let customResource: InferenceServiceK8s;
+    let docs: unknown[];
     try {
-      customResource = load(this.yaml) as InferenceServiceK8s;
+      docs = loadAll(this.yaml);
     } catch (e) {
       let msg = 'Could not parse the provided YAML';
 
@@ -83,86 +86,87 @@ export class SubmitFormComponent implements OnInit, OnDestroy {
         }
       }
 
-      const config: SnackBarConfig = {
-        data: {
-          msg,
-          snackType: SnackType.Error,
-        },
-        duration: 16000,
-      };
-      this.snack.open(config);
+      this.showError(msg);
       this.applying = false;
       return;
     }
 
-    if (!customResource) {
-      const config: SnackBarConfig = {
-        data: {
-          msg: 'YAML is empty or invalid',
-          snackType: SnackType.Error,
-        },
-        duration: 8000,
-      };
-      this.snack.open(config);
+    const validDocs = docs.filter(d => d != null);
+    if (validDocs.length === 0) {
+      this.showError('YAML is empty or invalid');
       this.applying = false;
       return;
     }
 
     const validationErrors: string[] = [];
+    const inferenceServices: InferenceServiceK8s[] = [];
+    const trainedModels: TrainedModelK8s[] = [];
 
-    if (!customResource.apiVersion) {
-      validationErrors.push('Missing required field: apiVersion');
+    for (const doc of validDocs) {
+      const resource = doc as any;
+      const kind = resource?.kind;
+
+      if (kind === 'InferenceService') {
+        validationErrors.push(...this.validateInferenceService(resource));
+        inferenceServices.push(resource as InferenceServiceK8s);
+      } else if (kind === 'TrainedModel') {
+        validationErrors.push(...this.validateTrainedModel(resource));
+        trainedModels.push(resource as TrainedModelK8s);
+      } else {
+        validationErrors.push(
+          `Unsupported resource kind: "${
+            kind || 'unknown'
+          }". Only InferenceService and TrainedModel are supported.`,
+        );
+      }
     }
-    if (!customResource.kind || customResource.kind !== 'InferenceService') {
+
+    if (inferenceServices.length === 0) {
       validationErrors.push(
-        'Missing or invalid field: kind (must be "InferenceService")',
+        'At least one InferenceService document is required.',
       );
     }
-    if (!customResource.metadata) {
-      validationErrors.push('Missing required field: metadata');
-    } else {
-      if (!customResource.metadata.name) {
-        validationErrors.push('Missing required field: metadata.name');
-      }
-    }
-    if (!customResource.spec) {
-      validationErrors.push('Missing required field: spec');
-    } else {
-      if (!customResource.spec.predictor) {
-        validationErrors.push('Missing required field: spec.predictor');
-      }
+
+    if (inferenceServices.length > 1) {
+      validationErrors.push(
+        'Only one InferenceService document is allowed per submission.',
+      );
     }
 
     if (validationErrors.length > 0) {
-      const config: SnackBarConfig = {
-        data: {
-          msg: validationErrors.join(' | '),
-          snackType: SnackType.Error,
-        },
-        duration: 16000,
-      };
-      this.snack.open(config);
+      this.showError(validationErrors.join(' | '), 16000);
       this.applying = false;
       return;
     }
 
-    customResource.metadata!.namespace = this.namespace;
+    const requests: Observable<MWABackendResponse>[] = [];
 
-    this.backend.postInferenceService(customResource).subscribe({
+    for (const svc of inferenceServices) {
+      svc.metadata!.namespace = this.namespace;
+      requests.push(this.backend.postInferenceService(svc));
+    }
+
+    for (const tm of trainedModels) {
+      if (!tm.metadata) {
+        tm.metadata = {};
+      }
+      tm.metadata.namespace = this.namespace;
+      requests.push(this.backend.postTrainedModel(tm));
+    }
+
+    forkJoin(requests).subscribe({
       next: () => {
-        const config: SnackBarConfig = {
-          data: {
-            msg: 'InferenceService created successfully.',
-            snackType: SnackType.Success,
-          },
-          duration: 3000,
-        };
-        this.snack.open(config);
+        const total = inferenceServices.length + trainedModels.length;
+        const msg =
+          total === 1
+            ? 'InferenceService created successfully.'
+            : `${total} resources created successfully.`;
+        this.showSuccess(msg);
         this.applying = false;
         this.navigateBack();
       },
       error: err => {
-        let errorMsg = 'Failed to create InferenceService';
+        let errorMsg = 'Failed to create resources';
 
         if (err?.error?.log) {
           errorMsg = err.error.log;
@@ -176,16 +180,68 @@ export class SubmitFormComponent implements OnInit, OnDestroy {
           errorMsg = `Server error: ${err.statusText}`;
         }
 
-        const config: SnackBarConfig = {
-          data: {
-            msg: errorMsg,
-            snackType: SnackType.Error,
-          },
-          duration: 16000,
-        };
-        this.snack.open(config);
+        this.showError(errorMsg, 16000);
         this.applying = false;
       },
     });
+  }
+
+  private validateInferenceService(resource: any): string[] {
+    const errors: string[] = [];
+    if (!resource.apiVersion) {
+      errors.push('InferenceService: Missing required field: apiVersion');
+    }
+    if (!resource.metadata) {
+      errors.push('InferenceService: Missing required field: metadata');
+    } else if (!resource.metadata.name) {
+      errors.push('InferenceService: Missing required field: metadata.name');
+    }
+    if (!resource.spec) {
+      errors.push('InferenceService: Missing required field: spec');
+    } else if (!resource.spec.predictor) {
+      errors.push('InferenceService: Missing required field: spec.predictor');
+    }
+    return errors;
+  }
+
+  private validateTrainedModel(resource: any): string[] {
+    const errors: string[] = [];
+    if (!resource.apiVersion) {
+      errors.push('TrainedModel: Missing required field: apiVersion');
+    }
+    if (!resource.metadata) {
+      errors.push('TrainedModel: Missing required field: metadata');
+    } else if (!resource.metadata.name) {
+      errors.push('TrainedModel: Missing required field: metadata.name');
+    }
+    if (!resource.spec) {
+      errors.push('TrainedModel: Missing required field: spec');
+    } else {
+      if (!resource.spec.inferenceService) {
+        errors.push(
+          'TrainedModel: Missing required field: spec.inferenceService',
+        );
+      }
+      if (!resource.spec.model) {
+        errors.push('TrainedModel: Missing required field: spec.model');
+      }
+    }
+    return errors;
+  }
+
+  private showError(msg: string, duration = 8000) {
+    const config: SnackBarConfig = {
+      data: { msg, snackType: SnackType.Error },
+      duration,
+    };
+    this.snack.open(config);
+  }
+
+  private showSuccess(msg: string) {
+    const config: SnackBarConfig = {
+      data: { msg, snackType: SnackType.Success },
+      duration: 3000,
+    };
+    this.snack.open(config);
   }
 }

--- a/frontend/src/app/pages/submit-form/submit-form.component.ts
+++ b/frontend/src/app/pages/submit-form/submit-form.component.ts
@@ -3,18 +3,27 @@ import { Router } from '@angular/router';
 import {
   NamespaceService,
   DashboardState,
+  K8sObject,
   SnackBarConfig,
   SnackBarService,
   SnackType,
 } from 'kubeflow';
 import { loadAll } from 'js-yaml';
-import { forkJoin, Observable } from 'rxjs';
-import { InferenceServiceK8s } from 'src/app/types/kfserving/v1beta1';
-import { TrainedModelK8s } from 'src/app/types/kfserving/v1alpha1';
+import { Subscription } from 'rxjs';
 import { MWABackendService } from 'src/app/services/backend.service';
 import { MWANamespaceService } from 'src/app/services/mwa-namespace.service';
-import { Subscription } from 'rxjs';
-import { MWABackendResponse } from 'src/app/types/backend';
+
+const SUPPORTED_KSERVE_RESOURCES = new Set([
+  'serving.kserve.io/v1beta1|InferenceService',
+  'serving.kserve.io/v1alpha1|InferenceGraph',
+  'serving.kserve.io/v1alpha1|TrainedModel',
+]);
+
+const SUPPORTED_KSERVE_RESOURCE_LABELS = [
+  'serving.kserve.io/v1beta1 InferenceService',
+  'serving.kserve.io/v1alpha1 InferenceGraph',
+  'serving.kserve.io/v1alpha1 TrainedModel',
+].join(', ');
 
 @Component({
   selector: 'app-submit-form',
@@ -71,6 +80,12 @@ export class SubmitFormComponent implements OnInit, OnDestroy {
   submit() {
     this.applying = true;
 
+    if (!this.namespace) {
+      this.showError('No namespace selected.');
+      this.applying = false;
+      return;
+    }
+
     let docs: unknown[];
     try {
       docs = loadAll(this.yaml);
@@ -91,7 +106,7 @@ export class SubmitFormComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const validDocs = docs.filter(d => d != null);
+    const validDocs = docs.filter(doc => doc != null);
     if (validDocs.length === 0) {
       this.showError('YAML is empty or invalid');
       this.applying = false;
@@ -99,39 +114,22 @@ export class SubmitFormComponent implements OnInit, OnDestroy {
     }
 
     const validationErrors: string[] = [];
-    const inferenceServices: InferenceServiceK8s[] = [];
-    const trainedModels: TrainedModelK8s[] = [];
+    const resources: K8sObject[] = [];
 
-    for (const doc of validDocs) {
-      const resource = doc as any;
-      const kind = resource?.kind;
-
-      if (kind === 'InferenceService') {
-        validationErrors.push(...this.validateInferenceService(resource));
-        inferenceServices.push(resource as InferenceServiceK8s);
-      } else if (kind === 'TrainedModel') {
-        validationErrors.push(...this.validateTrainedModel(resource));
-        trainedModels.push(resource as TrainedModelK8s);
-      } else {
+    validDocs.forEach((doc, index) => {
+      const documentIndex = index + 1;
+      if (!this.isResourceObject(doc)) {
         validationErrors.push(
-          `Unsupported resource kind: "${
-            kind || 'unknown'
-          }". Only InferenceService and TrainedModel are supported.`,
+          `Document ${documentIndex}: resource must be an object`,
         );
+      } else {
+        const resource = doc as K8sObject;
+        validationErrors.push(
+          ...this.validateResource(resource, documentIndex),
+        );
+        resources.push(resource);
       }
-    }
-
-    if (inferenceServices.length === 0) {
-      validationErrors.push(
-        'At least one InferenceService document is required.',
-      );
-    }
-
-    if (inferenceServices.length > 1) {
-      validationErrors.push(
-        'Only one InferenceService document is allowed per submission.',
-      );
-    }
+    });
 
     if (validationErrors.length > 0) {
       this.showError(validationErrors.join(' | '), 16000);
@@ -139,28 +137,15 @@ export class SubmitFormComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const requests: Observable<MWABackendResponse>[] = [];
+    resources.forEach(resource => this.setResourceNamespace(resource));
 
-    for (const svc of inferenceServices) {
-      svc.metadata!.namespace = this.namespace;
-      requests.push(this.backend.postInferenceService(svc));
-    }
-
-    for (const tm of trainedModels) {
-      if (!tm.metadata) {
-        tm.metadata = {};
-      }
-      tm.metadata.namespace = this.namespace;
-      requests.push(this.backend.postTrainedModel(tm));
-    }
-
-    forkJoin(requests).subscribe({
-      next: () => {
-        const total = inferenceServices.length + trainedModels.length;
+    this.backend.postKServeResources(this.namespace, resources).subscribe({
+      next: response => {
+        const total = response.createdResources?.length ?? resources.length;
         const msg =
           total === 1
-            ? 'InferenceService created successfully.'
-            : `${total} resources created successfully.`;
+            ? '1 KServe resource created successfully.'
+            : `${total} KServe resources created successfully.`;
         this.showSuccess(msg);
         this.applying = false;
         this.navigateBack();
@@ -186,47 +171,55 @@ export class SubmitFormComponent implements OnInit, OnDestroy {
     });
   }
 
-  private validateInferenceService(resource: any): string[] {
+  private isResourceObject(doc: unknown): doc is K8sObject {
+    return typeof doc === 'object' && doc !== null && !Array.isArray(doc);
+  }
+
+  private validateResource(
+    resource: K8sObject,
+    documentIndex: number,
+  ): string[] {
     const errors: string[] = [];
-    if (!resource.apiVersion) {
-      errors.push('InferenceService: Missing required field: apiVersion');
+    const customResource = resource as any;
+    const apiVersion = customResource.apiVersion;
+    const kind = customResource.kind;
+    const metadata = customResource.metadata;
+
+    if (!apiVersion) {
+      errors.push(
+        `Document ${documentIndex}: missing required field apiVersion`,
+      );
     }
-    if (!resource.metadata) {
-      errors.push('InferenceService: Missing required field: metadata');
-    } else if (!resource.metadata.name) {
-      errors.push('InferenceService: Missing required field: metadata.name');
+    if (!kind) {
+      errors.push(`Document ${documentIndex}: missing required field kind`);
     }
-    if (!resource.spec) {
-      errors.push('InferenceService: Missing required field: spec');
-    } else if (!resource.spec.predictor) {
-      errors.push('InferenceService: Missing required field: spec.predictor');
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+      errors.push(`Document ${documentIndex}: missing required field metadata`);
+    } else if (!metadata.name) {
+      errors.push(
+        `Document ${documentIndex}: missing required field metadata.name`,
+      );
+    }
+    if (customResource.spec == null) {
+      errors.push(`Document ${documentIndex}: missing required field spec`);
+    }
+
+    if (
+      apiVersion &&
+      kind &&
+      !SUPPORTED_KSERVE_RESOURCES.has(`${apiVersion}|${kind}`)
+    ) {
+      errors.push(
+        `Document ${documentIndex}: unsupported resource ${apiVersion} ${kind}. ` +
+          `Supported resources: ${SUPPORTED_KSERVE_RESOURCE_LABELS}`,
+      );
     }
     return errors;
   }
 
-  private validateTrainedModel(resource: any): string[] {
-    const errors: string[] = [];
-    if (!resource.apiVersion) {
-      errors.push('TrainedModel: Missing required field: apiVersion');
-    }
-    if (!resource.metadata) {
-      errors.push('TrainedModel: Missing required field: metadata');
-    } else if (!resource.metadata.name) {
-      errors.push('TrainedModel: Missing required field: metadata.name');
-    }
-    if (!resource.spec) {
-      errors.push('TrainedModel: Missing required field: spec');
-    } else {
-      if (!resource.spec.inferenceService) {
-        errors.push(
-          'TrainedModel: Missing required field: spec.inferenceService',
-        );
-      }
-      if (!resource.spec.model) {
-        errors.push('TrainedModel: Missing required field: spec.model');
-      }
-    }
-    return errors;
+  private setResourceNamespace(resource: K8sObject) {
+    const customResource = resource as any;
+    customResource.metadata.namespace = this.namespace;
   }
 
   private showError(msg: string, duration = 8000) {

--- a/frontend/src/app/pages/submit-form/submit-form.component.ts
+++ b/frontend/src/app/pages/submit-form/submit-form.component.ts
@@ -12,6 +12,7 @@ import { loadAll } from 'js-yaml';
 import { Subscription } from 'rxjs';
 import { MWABackendService } from 'src/app/services/backend.service';
 import { MWANamespaceService } from 'src/app/services/mwa-namespace.service';
+import { KServeResourceIdentity } from 'src/app/types/backend';
 
 const SUPPORTED_KSERVE_RESOURCES = new Set([
   'serving.kserve.io/v1beta1|InferenceService',
@@ -100,8 +101,11 @@ export class SubmitFormComponent implements OnInit, OnDestroy {
       return;
     }
 
-    const validDocs = docs.filter(doc => doc != null);
-    if (validDocs.length === 0) {
+    const resourceDocs = docs
+      .map((doc, index) => ({ doc, documentIndex: index + 1 }))
+      .filter(({ doc }) => doc != null);
+
+    if (resourceDocs.length === 0) {
       this.showError('YAML is empty or invalid');
       this.applying = false;
       return;
@@ -110,8 +114,7 @@ export class SubmitFormComponent implements OnInit, OnDestroy {
     const validationErrors: string[] = [];
     const resources: K8sObject[] = [];
 
-    validDocs.forEach((doc, index) => {
-      const documentIndex = index + 1;
+    resourceDocs.forEach(({ doc, documentIndex }) => {
       if (!this.isResourceObject(doc)) {
         validationErrors.push(
           `Document ${documentIndex}: resource must be an object`,
@@ -151,21 +154,7 @@ export class SubmitFormComponent implements OnInit, OnDestroy {
         this.navigateBack();
       },
       error: err => {
-        let errorMsg = 'Failed to create resources';
-
-        if (err?.error?.log) {
-          errorMsg = err.error.log;
-        } else if (err?.error?.message) {
-          errorMsg = err.error.message;
-        } else if (err?.error?.error) {
-          errorMsg = err.error.error;
-        } else if (typeof err?.error === 'string') {
-          errorMsg = err.error;
-        } else if (err?.statusText) {
-          errorMsg = `Server error: ${err.statusText}`;
-        }
-
-        this.showError(errorMsg, 16000);
+        this.showError(this.getCreateErrorMessage(err), 16000);
         this.applying = false;
       },
     });
@@ -220,6 +209,60 @@ export class SubmitFormComponent implements OnInit, OnDestroy {
   private setResourceNamespace(resource: K8sObject) {
     const customResource = resource as any;
     customResource.metadata.namespace = this.namespace;
+  }
+
+  private getCreateErrorMessage(err: any): string {
+    const baseMessage = this.getBackendErrorMessage(err);
+    const createdResources = err?.error?.createdResources;
+
+    if (!Array.isArray(createdResources) || createdResources.length === 0) {
+      return baseMessage;
+    }
+
+    const created = createdResources
+      .map(resource => this.formatResourceIdentity(resource))
+      .filter(Boolean)
+      .join(', ');
+
+    if (!created) {
+      return baseMessage;
+    }
+
+    return `${baseMessage} Already created: ${created}.`;
+  }
+
+  private getBackendErrorMessage(err: any): string {
+    if (err?.error?.log) {
+      return err.error.log;
+    }
+    if (err?.error?.message) {
+      return err.error.message;
+    }
+    if (err?.error?.error) {
+      return err.error.error;
+    }
+    if (typeof err?.error === 'string') {
+      return err.error;
+    }
+    if (err?.statusText) {
+      return `Server error: ${err.statusText}`;
+    }
+
+    return 'Failed to create resources';
+  }
+
+  private formatResourceIdentity(
+    resource: KServeResourceIdentity,
+  ): string | null {
+    if (!resource?.kind && !resource?.name) {
+      return null;
+    }
+
+    const kind = resource.kind || 'Resource';
+    const name = resource.name || '<unknown>';
+    const namespace = resource?.namespace ? ` in ${resource.namespace}` : '';
+
+    return `${kind}/${name}${namespace}`;
   }
 
   private showError(msg: string, duration = 8000) {

--- a/frontend/src/app/services/backend.service.ts
+++ b/frontend/src/app/services/backend.service.ts
@@ -4,7 +4,10 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { InferenceServiceK8s } from '../types/kfserving/v1beta1';
-import { InferenceGraphK8s } from '../types/kfserving/v1alpha1';
+import {
+  InferenceGraphK8s,
+  TrainedModelK8s,
+} from '../types/kfserving/v1alpha1';
 import { MWABackendResponse, InferenceServiceLogs } from '../types/backend';
 import { EventObject } from '../types/event';
 
@@ -253,6 +256,17 @@ export class MWABackendService extends BackendService {
 
     return this.http
       .post<MWABackendResponse>(url, inferenceGraph)
+      .pipe(catchError(error => this.handleError(error)));
+  }
+
+  public postTrainedModel(
+    trainedModel: TrainedModelK8s,
+  ): Observable<MWABackendResponse> {
+    const namespace = trainedModel.metadata!.namespace;
+    const url = `api/namespaces/${namespace}/trainedmodels`;
+
+    return this.http
+      .post<MWABackendResponse>(url, trainedModel)
       .pipe(catchError(error => this.handleError(error)));
   }
 

--- a/frontend/src/app/services/backend.service.ts
+++ b/frontend/src/app/services/backend.service.ts
@@ -4,10 +4,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { InferenceServiceK8s } from '../types/kfserving/v1beta1';
-import {
-  InferenceGraphK8s,
-  TrainedModelK8s,
-} from '../types/kfserving/v1alpha1';
+import { InferenceGraphK8s } from '../types/kfserving/v1alpha1';
 import { MWABackendResponse, InferenceServiceLogs } from '../types/backend';
 import { EventObject } from '../types/event';
 
@@ -259,14 +256,14 @@ export class MWABackendService extends BackendService {
       .pipe(catchError(error => this.handleError(error)));
   }
 
-  public postTrainedModel(
-    trainedModel: TrainedModelK8s,
+  public postKServeResources(
+    namespace: string,
+    resources: K8sObject[],
   ): Observable<MWABackendResponse> {
-    const namespace = trainedModel.metadata!.namespace;
-    const url = `api/namespaces/${namespace}/trainedmodels`;
+    const url = `api/namespaces/${namespace}/kserve-resources`;
 
     return this.http
-      .post<MWABackendResponse>(url, trainedModel)
+      .post<MWABackendResponse>(url, { resources })
       .pipe(catchError(error => this.handleError(error)));
   }
 

--- a/frontend/src/app/types/backend.ts
+++ b/frontend/src/app/types/backend.ts
@@ -8,6 +8,9 @@ export interface MWABackendResponse extends BackendResponse {
   inferenceService?: InferenceServiceK8s;
   inferenceGraphs?: InferenceGraphK8s[];
   inferenceGraph?: InferenceGraphK8s;
+  createdResources?: KServeResourceIdentity[];
+  failedDocumentIndex?: number;
+  failedResource?: KServeResourceIdentity;
   knativeService?: K8sObject;
   knativeConfiguration?: K8sObject;
   knativeRevision?: K8sObject;
@@ -21,6 +24,13 @@ export interface MWABackendResponse extends BackendResponse {
   modelmeshObjects?: ModelMeshObjects;
   logs?: string[];
   containers?: string[];
+}
+
+export interface KServeResourceIdentity {
+  apiVersion?: string;
+  kind?: string;
+  name?: string;
+  namespace?: string;
 }
 
 export interface InferenceServiceLogs {

--- a/frontend/src/app/types/kfserving/v1alpha1.ts
+++ b/frontend/src/app/types/kfserving/v1alpha1.ts
@@ -7,6 +7,20 @@ import {
 } from '@kubernetes/client-node';
 import { Params } from '@angular/router';
 
+export interface TrainedModelSpec {
+  inferenceService: string;
+  model: {
+    framework: string;
+    storageUri: string;
+    memory: string;
+  };
+}
+
+export interface TrainedModelK8s extends K8sObject {
+  metadata?: V1ObjectMeta;
+  spec?: TrainedModelSpec;
+}
+
 export interface InferenceGraphIR extends InferenceGraphK8s {
   // this type is used in the frontend after parsing the backend response
   ui: {

--- a/frontend/src/app/types/kfserving/v1alpha1.ts
+++ b/frontend/src/app/types/kfserving/v1alpha1.ts
@@ -7,20 +7,6 @@ import {
 } from '@kubernetes/client-node';
 import { Params } from '@angular/router';
 
-export interface TrainedModelSpec {
-  inferenceService: string;
-  model: {
-    framework: string;
-    storageUri: string;
-    memory: string;
-  };
-}
-
-export interface TrainedModelK8s extends K8sObject {
-  metadata?: V1ObjectMeta;
-  spec?: TrainedModelSpec;
-}
-
 export interface InferenceGraphIR extends InferenceGraphK8s {
   // this type is used in the frontend after parsing the backend response
   ui: {

--- a/manifests/kustomize/base/rbac.yaml
+++ b/manifests/kustomize/base/rbac.yaml
@@ -32,6 +32,8 @@ rules:
   - inferenceservices/status
   - inferencegraphs
   - inferencegraphs/status
+  - trainedmodels
+  - trainedmodels/status
   verbs:
   - get
   - list


### PR DESCRIPTION
### Summary

- Replace the TrainedModel-specific frontend fan-out with a backend-owned generic batch creation path.
- Support these namespaced KServe resources in v1: InferenceService, InferenceGraph, and TrainedModel.
- Create resources sequentially in YAML document order. Stop on the first failure and do not rollback already-created resources.

### Public API And Behavior
- Add POST /api/namespaces/<namespace>/kserve-resources.
- Request body:
```{ "resources": [ /* Kubernetes resource objects */ ] }```
- Success response includes a message and createdResources, each with apiVersion, kind, name, and namespace.
- Failure response includes a clear message, failed document index, failed resource identity when available, and any resources already created.
- The URL namespace is authoritative. Backend sets/overwrites each resource’s metadata.namespace to the route namespace before creation.
- Keep existing single-resource endpoints for backward compatibility, but make the create form use the new batch endpoint for both single-doc and multi-doc YAML.