### PR TITLE
Add read-only support for LLMInferenceService

### DIFF
--- a/backend/apps/common/routes/get.py
+++ b/backend/apps/common/routes/get.py
@@ -1,6 +1,7 @@
 """GET request handlers."""
 
 from flask import request
+from kubernetes.client.rest import ApiException
 
 from kubeflow.kubeflow.crud_backend import api, logging
 
@@ -179,6 +180,76 @@ def get_inference_graph(namespace, name):
 def get_inference_graph_events(namespace, name):
     """Return events for an InferenceGraph."""
     field_selector = api.events_field_selector("InferenceGraph", name)
+
+    events = api.events.list_events(namespace, field_selector).items
+
+    return api.success_response(
+        "events",
+        api.serialize(events),
+    )
+
+
+# The API server may serve either LLMInferenceService version. The first
+# request probes for the served version; every later request reuses the
+# detected value. Each worker process probes at most twice.
+_detected_llm_inference_service_version = None
+
+
+def _llm_inference_service_group_version_kind(namespace):
+    """Return the group, version and kind, detecting the served version."""
+    global _detected_llm_inference_service_version
+
+    if _detected_llm_inference_service_version is not None:
+        return versions.llm_inference_service_group_version_kind(
+            _detected_llm_inference_service_version
+        )
+
+    last_error = None
+    for candidate in versions.LLM_INFERENCE_SERVICE_VERSIONS:
+        group_version_kind = versions.llm_inference_service_group_version_kind(
+            candidate
+        )
+        try:
+            api.list_custom_rsrc(**group_version_kind, namespace=namespace)
+        except ApiException as error:
+            if error.status != 404:
+                raise
+            last_error = error
+            continue
+        _detected_llm_inference_service_version = candidate
+        log.info("Detected LLMInferenceService API version: %s", candidate)
+        return group_version_kind
+
+    raise last_error
+
+
+@bp.route("/api/namespaces/<namespace>/llminferenceservices")
+def get_llm_inference_services(namespace):
+    """Return a list of LLMInferenceService custom resources."""
+    group_version_kind = _llm_inference_service_group_version_kind(namespace)
+    llm_inference_services = api.list_custom_rsrc(
+        **group_version_kind, namespace=namespace
+    )
+
+    return api.success_response("llmInferenceServices", llm_inference_services["items"])
+
+
+@bp.route("/api/namespaces/<namespace>/llminferenceservices/<name>")
+def get_llm_inference_service(namespace, name):
+    """Return a single LLMInferenceService custom resource."""
+    llm_inference_service = api.get_custom_rsrc(
+        **_llm_inference_service_group_version_kind(namespace),
+        namespace=namespace,
+        name=name,
+    )
+
+    return api.success_response("llmInferenceService", llm_inference_service)
+
+
+@bp.route("/api/namespaces/<namespace>/llminferenceservices/<name>/events")
+def get_llm_inference_service_events(namespace, name):
+    """Return events that relate to an LLMInferenceService."""
+    field_selector = api.events_field_selector("LLMInferenceService", name)
 
     events = api.events.list_events(namespace, field_selector).items
 

--- a/backend/apps/common/routes/get_test.py
+++ b/backend/apps/common/routes/get_test.py
@@ -1,0 +1,187 @@
+"""Unit tests for the LLMInferenceService version-detection fallback.
+
+Run directly with:
+    python3 backend/apps/common/routes/get_test.py
+
+The version-detection helper tries v1alpha2 first and falls back to
+v1alpha1 only when the API server reports the resource as not found, then
+caches whichever version answered. This exact fallback also had a real
+consequence during development of this feature: a cluster that grants a
+service account no permission on llminferenceservices raises a 403, not a
+404, and the helper must surface that error immediately rather than
+mistaking a permission problem for an absent API version.
+"""
+
+import importlib.util
+import logging as python_logging
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest.mock import Mock
+
+from kubernetes.client.rest import ApiException
+
+
+def _load_get_routes_module():
+    """Load get.py with lightweight stubs for external dependencies.
+
+    The real versions.py is loaded as well, rather than stubbed, so the
+    tests also exercise its actual version ordering and group, version and
+    kind shape instead of assuming them.
+    """
+    module_names = (
+        "backend",
+        "backend.apps",
+        "backend.apps.common",
+        "backend.apps.common.routes",
+        "backend.apps.common.utils",
+        "backend.apps.common.versions",
+        "flask",
+        "kubeflow",
+        "kubeflow.kubeflow",
+        "kubeflow.kubeflow.crud_backend",
+    )
+    original_modules = {name: sys.modules.get(name) for name in module_names}
+
+    backend = types.ModuleType("backend")
+    apps = types.ModuleType("backend.apps")
+    common = types.ModuleType("backend.apps.common")
+    routes_package = types.ModuleType("backend.apps.common.routes")
+    utils = types.ModuleType("backend.apps.common.utils")
+    flask = types.ModuleType("flask")
+    kubeflow = types.ModuleType("kubeflow")
+    kubeflow_kubeflow = types.ModuleType("kubeflow.kubeflow")
+    crud_backend = types.ModuleType("kubeflow.kubeflow.crud_backend")
+
+    backend.__path__ = []
+    apps.__path__ = []
+    common.__path__ = []
+    routes_package.__path__ = []
+    routes_package.bp = Mock()
+    flask.request = types.SimpleNamespace()
+    # versions.py imports current_app at module scope for a function this
+    # test file does not exercise; it only needs to exist to satisfy the
+    # import.
+    flask.current_app = Mock()
+    crud_backend.api = types.SimpleNamespace(
+        list_custom_rsrc=Mock(),
+        get_custom_rsrc=Mock(),
+        success_response=Mock(),
+        serialize=Mock(),
+        events=types.SimpleNamespace(list_events=Mock()),
+        events_field_selector=Mock(),
+    )
+    crud_backend.logging = types.SimpleNamespace(
+        getLogger=lambda name: python_logging.getLogger(name)
+    )
+
+    try:
+        sys.modules["backend"] = backend
+        sys.modules["backend.apps"] = apps
+        sys.modules["backend.apps.common"] = common
+        sys.modules["backend.apps.common.routes"] = routes_package
+        sys.modules["backend.apps.common.utils"] = utils
+        sys.modules["flask"] = flask
+        sys.modules["kubeflow"] = kubeflow
+        sys.modules["kubeflow.kubeflow"] = kubeflow_kubeflow
+        sys.modules["kubeflow.kubeflow.crud_backend"] = crud_backend
+
+        versions_path = Path(__file__).parent.parent / "versions.py"
+        versions_spec = importlib.util.spec_from_file_location(
+            "backend.apps.common.versions", versions_path
+        )
+        versions_module = importlib.util.module_from_spec(versions_spec)
+        versions_spec.loader.exec_module(versions_module)
+        sys.modules["backend.apps.common.versions"] = versions_module
+
+        get_path = Path(__file__).with_name("get.py")
+        get_spec = importlib.util.spec_from_file_location(
+            "backend.apps.common.routes.get_under_test", get_path
+        )
+        get_module = importlib.util.module_from_spec(get_spec)
+        get_spec.loader.exec_module(get_module)
+        return get_module
+    finally:
+        for name, original_module in original_modules.items():
+            if original_module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original_module
+
+
+class LlmInferenceServiceVersionDetectionTest(unittest.TestCase):
+    def test_detects_v1alpha2_on_the_first_probe(self):
+        get_routes = _load_get_routes_module()
+        get_routes.api.list_custom_rsrc = Mock(return_value={"items": []})
+
+        group_version_kind = get_routes._llm_inference_service_group_version_kind(
+            "kubeflow-user"
+        )
+
+        self.assertEqual(
+            group_version_kind,
+            {
+                "group": "serving.kserve.io",
+                "version": "v1alpha2",
+                "kind": "llminferenceservices",
+            },
+        )
+        self.assertEqual(get_routes.api.list_custom_rsrc.call_count, 1)
+
+    def test_caches_the_detected_version_and_does_not_probe_again(self):
+        get_routes = _load_get_routes_module()
+        get_routes.api.list_custom_rsrc = Mock(return_value={"items": []})
+
+        get_routes._llm_inference_service_group_version_kind("kubeflow-user")
+        get_routes._llm_inference_service_group_version_kind("kubeflow-user")
+
+        self.assertEqual(get_routes.api.list_custom_rsrc.call_count, 1)
+
+    def test_falls_back_to_v1alpha1_when_v1alpha2_is_not_found(self):
+        get_routes = _load_get_routes_module()
+        get_routes.api.list_custom_rsrc = Mock(
+            side_effect=[ApiException(status=404), {"items": []}]
+        )
+
+        group_version_kind = get_routes._llm_inference_service_group_version_kind(
+            "kubeflow-user"
+        )
+
+        self.assertEqual(group_version_kind["version"], "v1alpha1")
+        self.assertEqual(get_routes.api.list_custom_rsrc.call_count, 2)
+
+    def test_reraises_a_permission_error_without_trying_the_fallback_version(self):
+        """
+        A service account without permission on llminferenceservices
+        receives a 403, not a 404. Falling back to v1alpha1 in that case
+        would mistake a permission problem for an absent API version and
+        mask the real cause.
+        """
+        get_routes = _load_get_routes_module()
+        forbidden = ApiException(status=403)
+        get_routes.api.list_custom_rsrc = Mock(side_effect=forbidden)
+
+        with self.assertRaises(ApiException) as raised:
+            get_routes._llm_inference_service_group_version_kind("kubeflow-user")
+
+        self.assertIs(raised.exception, forbidden)
+        self.assertEqual(get_routes.api.list_custom_rsrc.call_count, 1)
+
+    def test_reraises_the_last_not_found_error_when_no_version_is_served(self):
+        get_routes = _load_get_routes_module()
+        first_not_found = ApiException(status=404)
+        second_not_found = ApiException(status=404)
+        get_routes.api.list_custom_rsrc = Mock(
+            side_effect=[first_not_found, second_not_found]
+        )
+
+        with self.assertRaises(ApiException) as raised:
+            get_routes._llm_inference_service_group_version_kind("kubeflow-user")
+
+        self.assertIs(raised.exception, second_not_found)
+        self.assertEqual(get_routes.api.list_custom_rsrc.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/apps/common/versions.py
+++ b/backend/apps/common/versions.py
@@ -59,6 +59,27 @@ def inference_service_gvk():
     }
 
 
+LLM_INFERENCE_SERVICE_GROUP = "serving.kserve.io"
+# Newest first: v1alpha2 is the storage version on current KServe releases,
+# while older clusters may only serve v1alpha1.
+LLM_INFERENCE_SERVICE_VERSIONS = ["v1alpha2", "v1alpha1"]
+
+
+def llm_inference_service_group_version_kind(version):
+    """
+    Return the group, version and kind for an LLMInferenceService.
+
+    The caller supplies the API version because clusters differ in which
+    versions of the resource the API server serves; the route layer detects
+    the served version at runtime and passes it here.
+    """
+    return {
+        "group": LLM_INFERENCE_SERVICE_GROUP,
+        "version": version,
+        "kind": "llminferenceservices",
+    }
+
+
 def inference_graph_gvk():
     """
     Return the GVK needed for an InferenceGraph.

--- a/frontend/__mocks__/kubeflow.ts
+++ b/frontend/__mocks__/kubeflow.ts
@@ -28,8 +28,10 @@ export interface Status {
 }
 
 // Interface for Kubernetes object
+// The kind field is optional to match the real library declaration in
+// node_modules/kubeflow/lib/utils/kubernetes.model.d.ts.
 export interface K8sObject {
-  kind: string;
+  kind?: string;
   apiVersion?: string;
   metadata?: {
     name?: string;

--- a/frontend/cypress/e2e/index-page.cy.ts
+++ b/frontend/cypress/e2e/index-page.cy.ts
@@ -18,12 +18,7 @@ describe('Models Web App - Index Page Tests', () => {
       },
     }).as('getNamespaces');
 
-    // Default empty response for inference services
-    cy.intercept('GET', '/api/namespaces/*/inferenceservices', {
-      statusCode: 200,
-      body: [],
-    }).as('getInferenceServicesDefault');
-
+    cy.mockSse({ inferenceServices: [] });
     cy.visit('/');
   });
 
@@ -79,11 +74,8 @@ describe('Models Web App - Index Page Tests', () => {
   });
 
   it('should display empty state when no endpoints exist', () => {
-    // With the default empty intercept, verify empty state
     cy.wait('@getNamespaces');
-    cy.wait('@getInferenceServicesDefault');
 
-    // Table should exist and show empty state
     cy.get('lib-table', { timeout: 2000 }).should('exist');
     cy.get('lib-table').within(() => {
       cy.contains('No rows to display').should('be.visible');

--- a/frontend/cypress/e2e/llm-inference-service.cy.ts
+++ b/frontend/cypress/e2e/llm-inference-service.cy.ts
@@ -125,7 +125,7 @@ describe('Models Web App - LLMInferenceService Tests', () => {
 
     cy.get('lib-table', { timeout: 10000 }).should('exist');
     cy.contains(testServiceName, { timeout: 10000 }).should('be.visible');
-    cy.contains('Single node', { timeout: 10000 }).should('be.visible');
+    cy.contains('From configuration', { timeout: 10000 }).should('be.visible');
   });
 
   it('navigates to the details page when a name is clicked', () => {
@@ -188,7 +188,7 @@ describe('Models Web App - LLMInferenceService Tests', () => {
     cy.contains(testServiceName, { timeout: 10000 }).should('be.visible');
 
     // The overview tab renders the effective topology, not just raw YAML.
-    cy.contains('Single node', { timeout: 10000 }).should('be.visible');
+    cy.contains('From configuration', { timeout: 10000 }).should('be.visible');
     cy.contains('sample-single-node-configuration', { timeout: 10000 }).should(
       'be.visible',
     );

--- a/frontend/cypress/e2e/llm-inference-service.cy.ts
+++ b/frontend/cypress/e2e/llm-inference-service.cy.ts
@@ -1,0 +1,207 @@
+describe('Models Web App - LLMInferenceService Tests', () => {
+  const testServiceName = 'sample-facebook-opt-125m';
+  const testNamespace = 'kubeflow-user';
+
+  /*
+   * Modeled on a real object observed on a live cluster: a specification
+   * that references a base configuration the cluster had not installed,
+   * left at Ready Unknown with a failed PresetsCombined condition. That
+   * non-happy-path state is what a debugging user actually encounters, so
+   * it is a more useful fixture than an invented fully ready object.
+   */
+  const mockLLMInferenceService = {
+    apiVersion: 'serving.kserve.io/v1alpha2',
+    kind: 'LLMInferenceService',
+    metadata: {
+      name: testServiceName,
+      namespace: testNamespace,
+      creationTimestamp: '2024-01-01T00:00:00Z',
+    },
+    spec: {
+      baseRefs: [{ name: 'sample-single-node-configuration' }],
+      model: {
+        uri: 'hf://facebook/opt-125m',
+        name: 'facebook/opt-125m',
+      },
+    },
+    status: {
+      conditions: [
+        {
+          type: 'PresetsCombined',
+          status: 'False',
+          reason: 'ConfigNotFound',
+          message:
+            'LLMInferenceServiceConfig "kserve-config-llm-router-route" not found',
+        },
+        {
+          type: 'Ready',
+          status: 'Unknown',
+          reason: 'NewObservedGenFailure',
+        },
+      ],
+    },
+  };
+
+  beforeEach(() => {
+    cy.intercept('GET', '/api/config', {
+      statusCode: 200,
+      body: {
+        grafanaPrefix: '/grafana',
+        grafanaCpuMemoryDb: 'db/knative-serving-revision-cpu-and-memory-usage',
+        grafanaHttpRequestsDb: 'db/knative-serving-revision-http-requests',
+      },
+    }).as('getConfig');
+
+    cy.intercept('GET', '/api/namespaces', {
+      statusCode: 200,
+      body: {
+        namespaces: [{ name: testNamespace, status: 'Active' }],
+      },
+    }).as('getNamespacesList');
+
+    cy.intercept('GET', '/api/config/namespaces', {
+      statusCode: 200,
+      body: { namespaces: [testNamespace] },
+    }).as('getNamespaces');
+
+    cy.intercept('GET', '/api/namespaces/*/inferenceservices', {
+      statusCode: 200,
+      body: [],
+    }).as('getInferenceServices');
+
+    cy.intercept('GET', '**/dashboard_lib.bundle.js', {
+      statusCode: 200,
+      body: '',
+    });
+  });
+
+  it('navigates to the LLMInferenceServices page from the endpoints toolbar', () => {
+    cy.intercept(
+      'GET',
+      `/api/namespaces/${testNamespace}/llminferenceservices`,
+      {
+        statusCode: 200,
+        body: { llmInferenceServices: [] },
+      },
+    ).as('getLLMInferenceServicesEmpty');
+
+    cy.visit('/');
+    cy.wait('@getConfig');
+
+    cy.contains('button', 'View LLMInferenceServices').click();
+    cy.url().should('include', '/llm-inference-services');
+  });
+
+  it('loads the LLMInferenceServices page successfully', () => {
+    cy.intercept(
+      'GET',
+      `/api/namespaces/${testNamespace}/llminferenceservices`,
+      {
+        statusCode: 200,
+        body: { llmInferenceServices: [] },
+      },
+    ).as('getLLMInferenceServicesEmpty');
+
+    cy.visit('/llm-inference-services');
+    cy.wait('@getConfig');
+
+    cy.get('app-llm-inference-service', { timeout: 5000 }).should('exist');
+    cy.contains('LLMInferenceServices').should('be.visible');
+  });
+
+  it('displays LLMInferenceServices in a table with the derived topology and status', () => {
+    cy.intercept(
+      'GET',
+      `/api/namespaces/${testNamespace}/llminferenceservices`,
+      {
+        statusCode: 200,
+        body: { llmInferenceServices: [mockLLMInferenceService] },
+      },
+    ).as('getLLMInferenceServices');
+
+    cy.visit('/llm-inference-services');
+    cy.wait('@getConfig');
+    cy.wait('@getLLMInferenceServices');
+
+    cy.get('lib-table', { timeout: 10000 }).should('exist');
+    cy.contains(testServiceName, { timeout: 10000 }).should('be.visible');
+    cy.contains('Single node', { timeout: 10000 }).should('be.visible');
+  });
+
+  it('navigates to the details page when a name is clicked', () => {
+    cy.intercept(
+      'GET',
+      `/api/namespaces/${testNamespace}/llminferenceservices`,
+      {
+        statusCode: 200,
+        body: { llmInferenceServices: [mockLLMInferenceService] },
+      },
+    ).as('getLLMInferenceServices');
+
+    cy.intercept(
+      'GET',
+      `/api/namespaces/${testNamespace}/llminferenceservices/${testServiceName}`,
+      {
+        statusCode: 200,
+        body: { llmInferenceService: mockLLMInferenceService },
+      },
+    ).as('getLLMInferenceService');
+
+    cy.intercept(
+      'GET',
+      `/api/namespaces/${testNamespace}/llminferenceservices/${testServiceName}/events`,
+      { statusCode: 200, body: { events: [] } },
+    ).as('getEvents');
+
+    cy.visit('/llm-inference-services');
+    cy.wait('@getConfig');
+    cy.wait('@getLLMInferenceServices');
+
+    cy.contains(testServiceName, { timeout: 10000 }).click();
+
+    cy.url({ timeout: 10000 }).should('include', '/llm-details');
+    cy.get('app-llm-details', { timeout: 10000 }).should('exist');
+  });
+
+  it('displays the details page with conditions and the effective topology', () => {
+    cy.intercept(
+      'GET',
+      `/api/namespaces/${testNamespace}/llminferenceservices/${testServiceName}`,
+      {
+        statusCode: 200,
+        body: { llmInferenceService: mockLLMInferenceService },
+      },
+    ).as('getLLMInferenceService');
+
+    cy.intercept(
+      'GET',
+      `/api/namespaces/${testNamespace}/llminferenceservices/${testServiceName}/events`,
+      { statusCode: 200, body: { events: [] } },
+    ).as('getEvents');
+
+    cy.visit(`/llm-details/${testNamespace}/${testServiceName}`);
+    cy.wait('@getConfig');
+    cy.wait('@getLLMInferenceService', { timeout: 10000 });
+    cy.wait('@getEvents', { timeout: 10000 });
+
+    cy.get('app-llm-details', { timeout: 10000 }).should('exist');
+    cy.contains(testServiceName, { timeout: 10000 }).should('be.visible');
+
+    // The overview tab renders the effective topology, not just raw YAML.
+    cy.contains('Single node', { timeout: 10000 }).should('be.visible');
+    cy.contains('sample-single-node-configuration', { timeout: 10000 }).should(
+      'be.visible',
+    );
+
+    // The conditions table surfaces the failure message a debugging user
+    // needs, not only the resource's overall status icon.
+    cy.contains('PresetsCombined', { timeout: 10000 }).should('be.visible');
+    cy.contains('ConfigNotFound', { timeout: 10000 }).should('be.visible');
+
+    cy.contains('.mat-tab-label', 'YAML').click();
+    cy.get('.yaml-content', { timeout: 10000 }).should(
+      'contain.text',
+      testServiceName,
+    );
+  });
+});

--- a/frontend/cypress/e2e/model-deletion.cy.ts
+++ b/frontend/cypress/e2e/model-deletion.cy.ts
@@ -1,4 +1,59 @@
 describe('Models Web App - Model Deletion Tests', () => {
+  const inferenceServices = [
+    {
+      metadata: {
+        name: 'test-sklearn-model',
+        namespace: 'kubeflow-user',
+        creationTimestamp: '2024-01-15T10:30:00Z',
+      },
+      spec: {
+        predictor: {
+          sklearn: {
+            storageUri: 'gs://test-bucket/sklearn-model',
+            runtimeVersion: '0.24.1',
+            protocolVersion: 'v1',
+          },
+        },
+      },
+      status: {
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'True',
+            lastTransitionTime: '2024-01-15T10:35:00Z',
+          },
+        ],
+        url: 'http://test-sklearn-model.kubeflow-user.example.com',
+      },
+    },
+    {
+      metadata: {
+        name: 'test-tensorflow-model',
+        namespace: 'kubeflow-user',
+        creationTimestamp: '2024-01-15T11:00:00Z',
+      },
+      spec: {
+        predictor: {
+          tensorflow: {
+            storageUri: 'gs://test-bucket/tensorflow-model',
+            runtimeVersion: '2.8.0',
+            protocolVersion: 'v1',
+          },
+        },
+      },
+      status: {
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'True',
+            lastTransitionTime: '2024-01-15T11:05:00Z',
+          },
+        ],
+        url: 'http://test-tensorflow-model.kubeflow-user.example.com',
+      },
+    },
+  ];
+
   beforeEach(() => {
     // Mock the configuration API that's loaded during app initialization
     cy.intercept('GET', '/api/config', {
@@ -18,65 +73,7 @@ describe('Models Web App - Model Deletion Tests', () => {
       },
     }).as('getNamespaces');
 
-    // Mock inference services with sample data for deletion testing
-    cy.intercept('GET', '/api/namespaces/kubeflow-user/inferenceservices', {
-      statusCode: 200,
-      body: [
-        {
-          metadata: {
-            name: 'test-sklearn-model',
-            namespace: 'kubeflow-user',
-            creationTimestamp: '2024-01-15T10:30:00Z',
-          },
-          spec: {
-            predictor: {
-              sklearn: {
-                storageUri: 'gs://test-bucket/sklearn-model',
-                runtimeVersion: '0.24.1',
-                protocolVersion: 'v1',
-              },
-            },
-          },
-          status: {
-            conditions: [
-              {
-                type: 'Ready',
-                status: 'True',
-                lastTransitionTime: '2024-01-15T10:35:00Z',
-              },
-            ],
-            url: 'http://test-sklearn-model.kubeflow-user.example.com',
-          },
-        },
-        {
-          metadata: {
-            name: 'test-tensorflow-model',
-            namespace: 'kubeflow-user',
-            creationTimestamp: '2024-01-15T11:00:00Z',
-          },
-          spec: {
-            predictor: {
-              tensorflow: {
-                storageUri: 'gs://test-bucket/tensorflow-model',
-                runtimeVersion: '2.8.0',
-                protocolVersion: 'v1',
-              },
-            },
-          },
-          status: {
-            conditions: [
-              {
-                type: 'Ready',
-                status: 'True',
-                lastTransitionTime: '2024-01-15T11:05:00Z',
-              },
-            ],
-            url: 'http://test-tensorflow-model.kubeflow-user.example.com',
-          },
-        },
-      ],
-    }).as('getInferenceServicesWithData');
-
+    cy.mockSse({ inferenceServices });
     cy.visit('/');
     cy.wait('@getConfig');
     cy.wait('@getNamespaces');
@@ -91,20 +88,14 @@ describe('Models Web App - Model Deletion Tests', () => {
   });
 
   it('should display inference services table', () => {
-    // Wait for inference services to load
-    cy.wait('@getInferenceServicesWithData', { timeout: 10000 });
-
-    // Verify table is present
     cy.get('lib-table', { timeout: 5000 }).should('exist');
+    cy.get('lib-table').should('contain', 'test-sklearn-model');
   });
 
   it('should display models when data is loaded', () => {
-    // Wait for inference services to load
-    cy.wait('@getInferenceServicesWithData', { timeout: 10000 });
-
-    // Verify the table component exists and has data
     cy.get('lib-table').should('be.visible');
-    // Check for table rows
+    cy.get('lib-table').should('contain', 'test-sklearn-model');
+    cy.get('lib-table').should('contain', 'test-tensorflow-model');
     cy.get('lib-table .mat-row, lib-table tr').should(
       'have.length.greaterThan',
       0,
@@ -112,13 +103,9 @@ describe('Models Web App - Model Deletion Tests', () => {
   });
 
   it('should handle table interactions', () => {
-    // Wait for inference services to load
-    cy.wait('@getInferenceServicesWithData', { timeout: 10000 });
-
-    // Verify table has content
     cy.get('lib-table', { timeout: 5000 }).should('be.visible');
+    cy.get('lib-table').should('contain', 'test-sklearn-model');
 
-    // Try to find actionable elements in the table
     cy.get('lib-table button, lib-table [role="button"]').should(
       'have.length.greaterThan',
       0,
@@ -126,10 +113,9 @@ describe('Models Web App - Model Deletion Tests', () => {
   });
 
   it('should have properly structured table layout', () => {
-    cy.wait('@getInferenceServicesWithData', { timeout: 10000 });
+    cy.get('lib-table').should('contain', 'test-sklearn-model');
 
     cy.get('lib-table').within(() => {
-      // Check for table header elements
       cy.get('.mat-header-row, thead, [role="columnheader"]', {
         timeout: 5000,
       }).should('exist');

--- a/frontend/cypress/e2e/model-edit.cy.ts
+++ b/frontend/cypress/e2e/model-edit.cy.ts
@@ -10,22 +10,6 @@ interface AceStatic {
 
 interface CypressWindowWithExtensions {
   ace: AceStatic;
-  EventSource: {
-    new (url: string): {
-      readyState: number;
-      onerror: ((e: Event) => void) | null;
-      onopen: ((e: Event) => void) | null;
-      onmessage: ((e: MessageEvent) => void) | null;
-      close(): void;
-      addEventListener(): void;
-      removeEventListener(): void;
-      dispatchEvent(): boolean;
-    };
-    CONNECTING: 0 | number;
-    OPEN: 1 | number;
-    CLOSED: 2 | number;
-  };
-  setTimeout: Window['setTimeout'];
 }
 
 describe('Models Web App - Model Edit Tests', () => {
@@ -162,55 +146,8 @@ describe('Models Web App - Model Edit Tests', () => {
       statusCode: 404,
     }).as('getGrafana');
 
-    cy.visit('/details/kubeflow-user/test-sklearn-model', {
-      onBeforeLoad(win) {
-        const initialData = JSON.stringify({
-          type: 'INITIAL',
-          object: testModel,
-        });
-
-        class FakeEventSource {
-          static CONNECTING = 0;
-          static OPEN = 1;
-          static CLOSED = 2;
-          readyState = 1;
-          onerror: ((e: Event) => void) | null = null;
-          onopen: ((e: Event) => void) | null = null;
-          onmessage: ((e: MessageEvent) => void) | null = null;
-
-          constructor(url: string) {
-            if (url.includes('inferenceservices/test-sklearn-model')) {
-              win.setTimeout(() => {
-                if (this.onmessage) {
-                  this.onmessage(
-                    new MessageEvent('message', {
-                      data: initialData,
-                    }),
-                  );
-                }
-              }, 10);
-            } else {
-              this.readyState = 2;
-              win.setTimeout(() => {
-                if (this.onerror) this.onerror(new Event('error'));
-              }, 50);
-            }
-          }
-
-          close() {
-            this.readyState = 2;
-          }
-          addEventListener() {}
-          removeEventListener() {}
-          dispatchEvent() {
-            return false;
-          }
-        }
-
-        (win as unknown as CypressWindowWithExtensions).EventSource =
-          FakeEventSource;
-      },
-    });
+    cy.mockSse({ inferenceServices: [testModel] });
+    cy.visit('/details/kubeflow-user/test-sklearn-model');
   });
 
   it('should load model details page and show edit button', () => {
@@ -477,26 +414,7 @@ describe('Models Web App - Model Edit Tests', () => {
       }
       return true;
     });
-    cy.intercept('GET', '/api/namespaces/kubeflow-user/inferenceservices', {
-      statusCode: 200,
-      body: { inferenceServices: [testModel] },
-    }).as('getInferenceServicesList');
-
-    cy.intercept('GET', '/api/sse/namespaces/kubeflow-user/inferenceservices', {
-      statusCode: 200,
-      headers: {
-        'Content-Type': 'text/event-stream',
-        'Cache-Control': 'no-cache',
-      },
-      body: `data: ${JSON.stringify({
-        type: 'INITIAL',
-        items: [testModel],
-      })}\n\n`,
-    }).as('watchInferenceServicesList');
-
-    // Wait for config to be loaded first
     cy.wait('@getConfig');
-
     cy.wait('@getRevision');
     cy.wait('@getConfiguration');
     cy.wait('@getKnativeService');
@@ -508,5 +426,6 @@ describe('Models Web App - Model Edit Tests', () => {
     // Verify navigation back to index
     cy.url().should('not.include', '/details');
     cy.get('app-index').should('exist');
+    cy.get('lib-table').should('contain', 'test-sklearn-model');
   });
 });

--- a/frontend/cypress/e2e/namespace-configuration.cy.ts
+++ b/frontend/cypress/e2e/namespace-configuration.cy.ts
@@ -10,11 +10,7 @@ describe('Models Web App - Namespace Configuration Tests', () => {
       },
     }).as('getConfig');
 
-    // Default empty response for inference services
-    cy.intercept('GET', '/api/namespaces/*/inferenceservices', {
-      statusCode: 200,
-      body: [],
-    }).as('getInferenceServices');
+    cy.mockSse({ inferenceServices: [] });
   });
 
   describe('Default Behavior (All Namespaces)', () => {
@@ -120,8 +116,19 @@ describe('Models Web App - Namespace Configuration Tests', () => {
         cy.get('.namespace-value').should('contain', 'kubeflow-user');
       });
 
-      // The inference services API should be called with the auto-selected namespace
-      cy.wait('@getInferenceServices');
+      cy.window().should(win => {
+        const sources = (
+          win as Window & { __cypressSseSources?: Array<{ url: string }> }
+        ).__cypressSseSources;
+        expect(
+          sources?.some(source =>
+            /\/namespaces\/kubeflow-user\/inferenceservices\/?$/.test(
+              source.url,
+            ),
+          ),
+          'SSE list watch for the auto-selected namespace',
+        ).to.equal(true);
+      });
     });
   });
 
@@ -329,6 +336,18 @@ describe('Models Web App - Namespace Configuration Tests', () => {
   });
 
   describe('Integration with Main App', () => {
+    const kubeflowUserService = {
+      metadata: {
+        name: 'test-model',
+        namespace: 'kubeflow-user',
+        creationTimestamp: '2024-01-01T00:00:00Z',
+      },
+      spec: {
+        predictor: { sklearn: { storageUri: 's3://bucket/model' } },
+      },
+      status: { url: 'http://test-model.example.com' },
+    };
+
     beforeEach(() => {
       cy.intercept('GET', '/api/config/namespaces', {
         statusCode: 200,
@@ -339,28 +358,12 @@ describe('Models Web App - Namespace Configuration Tests', () => {
         },
       }).as('getNamespaces');
 
-      // Intercept specific namespace API calls for data loading
-      cy.intercept('GET', '/api/namespaces/kubeflow-user/inferenceservices', {
-        statusCode: 200,
-        body: [
-          {
-            metadata: {
-              name: 'test-model',
-              namespace: 'kubeflow-user',
-              creationTimestamp: '2024-01-01T00:00:00Z',
-            },
-            spec: {
-              predictor: { sklearn: { storageUri: 's3://bucket/model' } },
-            },
-            status: { url: 'http://test-model.example.com' },
-          },
-        ],
-      }).as('getKubeflowUserServices');
-
-      cy.intercept('GET', '/api/namespaces/test-ns-1/inferenceservices', {
-        statusCode: 200,
-        body: [],
-      }).as('getTestNs1Services');
+      cy.mockSse({
+        byNamespace: {
+          'kubeflow-user': [kubeflowUserService],
+          'test-ns-1': [],
+        },
+      });
 
       cy.visit('/');
       cy.wait('@getConfig');
@@ -368,41 +371,23 @@ describe('Models Web App - Namespace Configuration Tests', () => {
     });
 
     it('should trigger inference services refresh when namespace changes', () => {
-      // First, make sure we're starting from a known state
-      // Select the first namespace to trigger the initial API call
-      cy.get('app-namespace-select').within(() => {
-        cy.get('mat-select').click();
-      });
-      cy.get('mat-option').contains('kubeflow-user').click();
+      cy.get('lib-table', { timeout: 10000 }).should('contain', 'test-model');
 
-      // Should trigger API call for selected namespace
-      cy.wait('@getKubeflowUserServices', { timeout: 5000 });
-
-      // Verify the table updates (may be empty or with data)
-      cy.get('lib-table', { timeout: 10000 }).should('be.visible');
-
-      // Now change to different namespace
       cy.get('app-namespace-select').within(() => {
         cy.get('mat-select').click();
       });
       cy.get('mat-option').contains('test-ns-1').click();
 
-      cy.wait('@getTestNs1Services', { timeout: 5000 });
+      cy.get('lib-table', { timeout: 10000 }).within(() => {
+        cy.contains('No rows to display').should('be.visible');
+      });
 
-      // Table should still be visible
-      cy.get('lib-table', { timeout: 10000 }).should('be.visible');
-
-      // Change back to kubeflow-user to verify it can switch again
       cy.get('app-namespace-select').within(() => {
         cy.get('mat-select').click();
       });
       cy.get('mat-option').contains('kubeflow-user').click();
 
-      // This should make another call
-      cy.wait('@getKubeflowUserServices', { timeout: 5000 });
-
-      // Table should still be visible
-      cy.get('lib-table', { timeout: 10000 }).should('be.visible');
+      cy.get('lib-table', { timeout: 10000 }).should('contain', 'test-model');
     });
 
     it('should update "New Endpoint" button namespace context', () => {

--- a/frontend/cypress/e2e/sse.cy.ts
+++ b/frontend/cypress/e2e/sse.cy.ts
@@ -36,6 +36,20 @@ describe('Models Web App - Server-Sent Events (SSE) Tests', () => {
       },
     },
   };
+
+  const secondInferenceService = {
+    ...mockInferenceService,
+    metadata: {
+      ...mockInferenceService.metadata,
+      name: 'second-model',
+      uid: 'test-uid-456',
+    },
+    status: {
+      ...mockInferenceService.status,
+      url: 'http://second-model.kubeflow-user.example.com',
+    },
+  };
+
   beforeEach(() => {
     cy.on('uncaught:exception', err => {
       if (err.message.includes('403') || err.message.includes('Forbidden')) {
@@ -43,249 +57,108 @@ describe('Models Web App - Server-Sent Events (SSE) Tests', () => {
       }
       return true;
     });
+
+    cy.intercept('GET', '/api/config', {
+      statusCode: 200,
+      body: {
+        grafanaPrefix: '/grafana',
+        grafanaCpuMemoryDb: 'db/knative-serving-revision-cpu-and-memory-usage',
+        grafanaHttpRequestsDb: 'db/knative-serving-revision-http-requests',
+      },
+    }).as('config');
+
+    cy.intercept('GET', '/api/config/namespaces', {
+      statusCode: 200,
+      body: { namespaces: ['kubeflow-user'] },
+    }).as('namespaces');
   });
 
-  describe('SSE Endpoints Availability', () => {
-    it('should load index page and have SSE endpoints available', () => {
-      cy.intercept('GET', '/api/config', {
-        statusCode: 200,
-        body: {
-          grafanaPrefix: '/grafana',
-          grafanaCpuMemoryDb:
-            'db/knative-serving-revision-cpu-and-memory-usage',
-          grafanaHttpRequestsDb: 'db/knative-serving-revision-http-requests',
-        },
-      }).as('config');
+  it('should load the index page over SSE', () => {
+    cy.mockSse({ inferenceServices: [mockInferenceService] });
+    cy.visit('/');
+    cy.wait('@config');
+    cy.wait('@namespaces');
 
-      cy.intercept('GET', '/api/config/namespaces', {
-        statusCode: 200,
-        body: { namespaces: ['kubeflow-user'] },
-      });
-
-      cy.intercept('GET', '/api/namespaces/*/inferenceservices', {
-        statusCode: 200,
-        body: { inferenceServices: [mockInferenceService] },
-      });
-
-      cy.visit('/');
-      cy.wait('@config');
-      cy.contains('Endpoints').should('be.visible');
-    });
+    cy.contains('Endpoints').should('be.visible');
+    cy.get('lib-table').should('contain', 'test-model');
   });
 
-  describe('Inference Services List - Polling Fallback', () => {
-    it('should display list of InferenceServices using polling', () => {
-      cy.intercept('GET', '/api/config', {
-        statusCode: 200,
-        body: {
-          grafanaPrefix: '/grafana',
-        },
-      }).as('config');
+  it('should display InferenceServices from the SSE INITIAL snapshot', () => {
+    cy.mockSse({ inferenceServices: [mockInferenceService] });
+    cy.visit('/');
+    cy.wait('@config');
+    cy.wait('@namespaces');
 
-      cy.intercept('GET', '/api/config/namespaces', {
-        statusCode: 200,
-        body: { namespaces: ['kubeflow-user'] },
-      }).as('namespaces');
+    cy.get('lib-table').should('be.visible');
+    cy.get('lib-table').should('contain', 'test-model');
+  });
 
-      cy.intercept('GET', '/api/namespaces/*/inferenceservices', {
-        statusCode: 200,
-        body: { inferenceServices: [mockInferenceService] },
-      }).as('getServices');
-
-      cy.visit('/');
-      cy.wait('@config');
-      cy.wait('@namespaces');
-      cy.wait('@getServices', { timeout: 5000 });
-
-      cy.wait(500);
-
-      cy.get('lib-table').should('be.visible');
+  it('should display multiple InferenceServices from SSE', () => {
+    cy.mockSse({
+      inferenceServices: [mockInferenceService, secondInferenceService],
     });
+    cy.visit('/');
+    cy.wait('@config');
+    cy.wait('@namespaces');
 
-    it('should handle multiple InferenceServices', () => {
-      const service2 = {
-        ...mockInferenceService,
-        metadata: {
-          ...mockInferenceService.metadata,
-          name: 'second-model',
-        },
-      };
+    cy.get('lib-table').should('contain', 'test-model');
+    cy.get('lib-table').should('contain', 'second-model');
+  });
 
-      cy.intercept('GET', '/api/config', {
-        statusCode: 200,
-        body: { grafanaPrefix: '/grafana' },
-      }).as('config');
+  it('should display empty state when SSE returns no services', () => {
+    cy.mockSse({ inferenceServices: [] });
+    cy.visit('/');
+    cy.wait('@config');
+    cy.wait('@namespaces');
 
-      cy.intercept('GET', '/api/config/namespaces', {
-        statusCode: 200,
-        body: { namespaces: ['kubeflow-user'] },
-      }).as('namespaces');
-
-      cy.intercept('GET', '/api/namespaces/*/inferenceservices', {
-        statusCode: 200,
-        body: { inferenceServices: [mockInferenceService, service2] },
-      }).as('services');
-
-      cy.visit('/');
-      cy.wait('@config');
-      cy.wait('@namespaces');
-      cy.wait('@services', { timeout: 5000 });
-
-      cy.wait(500);
-
-      // Verify table shows records
-      cy.get('lib-table').should('be.visible');
-    });
-
-    it('should display empty state when no services exist', () => {
-      cy.intercept('GET', '/api/config', {
-        statusCode: 200,
-        body: { sseEnabled: true },
-      });
-
-      cy.intercept('GET', '/api/config/namespaces', {
-        statusCode: 200,
-        body: { namespaces: ['kubeflow-user'] },
-      });
-
-      cy.intercept('GET', '/api/namespaces/*/inferenceservices', {
-        statusCode: 200,
-        body: { inferenceServices: [] },
-      });
-
-      cy.visit('/');
-
-      cy.get('lib-table').within(() => {
-        cy.contains('No rows to display').should('be.visible');
-      });
+    cy.get('lib-table').within(() => {
+      cy.contains('No rows to display').should('be.visible');
     });
   });
 
-  describe('Fallback from SSE to Polling', () => {
-    it('should fallback to polling when SSE endpoint fails', () => {
-      // SSE returns error
-      cy.intercept('GET', '/api/sse/**', {
-        statusCode: 503,
-        body: { error: 'SSE unavailable' },
-      });
+  it('should append a row when SSE emits ADDED', () => {
+    cy.mockSse({ inferenceServices: [mockInferenceService] });
+    cy.visit('/');
+    cy.wait('@config');
+    cy.wait('@namespaces');
+    cy.get('lib-table').should('contain', 'test-model');
 
-      cy.intercept('GET', '/api/config', {
-        statusCode: 200,
-        body: {
-          grafanaPrefix: '/grafana',
-        },
-      }).as('config');
+    cy.emitSse({ type: 'ADDED', object: secondInferenceService });
 
-      cy.intercept('GET', '/api/config/namespaces', {
-        statusCode: 200,
-        body: { namespaces: ['kubeflow-user'] },
-      }).as('namespaces');
+    cy.get('lib-table').should('contain', 'second-model');
+  });
 
-      // Polling API works
-      cy.intercept('GET', '/api/namespaces/*/inferenceservices', {
-        statusCode: 200,
-        body: { inferenceServices: [mockInferenceService] },
-      }).as('fallbackPolling');
+  it('should remove a row when SSE emits DELETED', () => {
+    cy.mockSse({ inferenceServices: [mockInferenceService] });
+    cy.visit('/');
+    cy.wait('@config');
+    cy.wait('@namespaces');
+    cy.get('lib-table').should('contain', 'test-model');
 
-      cy.visit('/');
+    cy.emitSse({ type: 'DELETED', object: mockInferenceService });
 
-      cy.wait('@config');
-      cy.wait('@namespaces');
-      cy.wait('@fallbackPolling');
-      cy.wait(500);
-
-      // Data should still load via polling fallback
-      cy.get('lib-table').should('be.visible');
-    });
-
-    it('should handle SSE network errors gracefully', () => {
-      // SSE endpoint times out or is unreachable
-      cy.intercept(
-        'GET',
-        '/api/sse/namespaces/kubeflow-user/inferenceservices',
-        {
-          statusCode: 0,
-          forceNetworkError: true,
-        },
-      );
-
-      cy.intercept('GET', '/api/config', {
-        statusCode: 200,
-        body: { grafanaPrefix: '/grafana' },
-      }).as('config');
-
-      cy.intercept('GET', '/api/config/namespaces', {
-        statusCode: 200,
-        body: { namespaces: ['kubeflow-user'] },
-      }).as('namespaces');
-
-      cy.intercept('GET', '/api/namespaces/*/inferenceservices', {
-        statusCode: 200,
-        body: { inferenceServices: [mockInferenceService] },
-      }).as('polling');
-
-      cy.visit('/');
-
-      cy.wait('@config');
-      cy.wait('@namespaces');
-      cy.wait('@polling');
-      cy.wait(500);
-
-      cy.get('lib-table').should('be.visible');
+    cy.get('lib-table').within(() => {
+      cy.contains('No rows to display').should('be.visible');
     });
   });
 
-  describe('Service Details Page with SSE', () => {
-    it('should provide service details API for individual services', () => {
-      cy.intercept('GET', '/api/config', {
-        statusCode: 200,
-        body: { grafanaPrefix: '/grafana' },
-      }).as('config');
+  it('should watch the selected namespace over SSE', () => {
+    cy.mockSse({ inferenceServices: [mockInferenceService] });
+    cy.visit('/');
+    cy.wait('@config');
+    cy.wait('@namespaces');
+    cy.get('lib-table').should('contain', 'test-model');
 
-      cy.intercept('GET', '/api/config/namespaces', {
-        statusCode: 200,
-        body: { namespaces: ['kubeflow-user'] },
-      }).as('namespaces');
-
-      cy.intercept('GET', '/api/namespaces/kubeflow-user/inferenceservices', {
-        statusCode: 200,
-        body: { inferenceServices: [mockInferenceService] },
-      }).as('servicesList');
-
-      cy.visit('/');
-
-      cy.wait('@config');
-      cy.wait('@servicesList');
-      cy.wait(500);
-
-      cy.contains('Endpoints').should('be.visible');
-    });
-  });
-
-  describe('Real-time SSE Capability', () => {
-    it('should support real-time updates via SSE when available', () => {
-      cy.intercept('GET', '/api/config', {
-        statusCode: 200,
-        body: {
-          grafanaPrefix: '/grafana',
-        },
-      }).as('getConfig');
-
-      cy.intercept('GET', '/api/config/namespaces', {
-        statusCode: 200,
-        body: { namespaces: ['kubeflow-user'] },
-      });
-
-      cy.intercept('GET', '/api/namespaces/kubeflow-user/inferenceservices', {
-        statusCode: 200,
-        body: { inferenceServices: [mockInferenceService] },
-      });
-
-      cy.visit('/');
-
-      cy.wait('@getConfig');
-
-      cy.contains('Endpoints').should('be.visible');
+    cy.window().should(win => {
+      const sources = (
+        win as Window & { __cypressSseSources?: Array<{ url: string }> }
+      ).__cypressSseSources;
+      expect(
+        sources?.some(source =>
+          /\/namespaces\/kubeflow-user\/inferenceservices\/?$/.test(source.url),
+        ),
+        'SSE list watch for kubeflow-user',
+      ).to.equal(true);
     });
   });
 });

--- a/frontend/cypress/support/commands.ts
+++ b/frontend/cypress/support/commands.ts
@@ -1,3 +1,10 @@
+import {
+  emitSseOnWindow,
+  setSseMockOptions,
+  SseMockOptions,
+  SseWatchEvent,
+} from './sse-mock';
+
 declare global {
   namespace Cypress {
     interface Chainable {
@@ -11,6 +18,17 @@ declare global {
        * Custom command to wait for Angular to be ready
        */
       waitForAngular(): Chainable<void>;
+
+      /**
+       * Configure InferenceService data delivered over the mocked EventSource.
+       * Must run before cy.visit().
+       */
+      mockSse(options?: SseMockOptions): Chainable<void>;
+
+      /**
+       * Push a watch event to an open mocked EventSource.
+       */
+      emitSse(event: SseWatchEvent, urlIncludes?: string): Chainable<void>;
     }
   }
 }
@@ -43,5 +61,22 @@ Cypress.Commands.add('waitForAngular', () => {
     });
   });
 });
+
+Cypress.Commands.add('mockSse', (options: SseMockOptions = {}) => {
+  setSseMockOptions(options);
+});
+
+Cypress.Commands.add(
+  'emitSse',
+  (event: SseWatchEvent, urlIncludes?: string) => {
+    cy.window().then(win => {
+      const emitted = emitSseOnWindow(win, event, urlIncludes);
+      expect(
+        emitted,
+        'at least one open EventSource matching the watch URL',
+      ).to.be.greaterThan(0);
+    });
+  },
+);
 
 export {};

--- a/frontend/cypress/support/e2e.ts
+++ b/frontend/cypress/support/e2e.ts
@@ -1,7 +1,18 @@
 import './commands';
+import { installSseMock, resetSseMock } from './sse-mock';
+
+beforeEach(() => {
+  resetSseMock();
+  // Safety net: if polling fallback still runs, do not hit a live cluster.
+  cy.intercept('GET', '/api/namespaces/*/inferenceservices', {
+    statusCode: 200,
+    body: { inferenceServices: [] },
+  });
+});
 
 // Hide fetch/XHR requests from command log
 Cypress.on('window:before:load', win => {
+  installSseMock(win);
   cy.stub(win.console, 'log').as('consoleLog');
   cy.stub(win.console, 'error').as('consoleError');
 });

--- a/frontend/cypress/support/sse-mock.ts
+++ b/frontend/cypress/support/sse-mock.ts
@@ -1,0 +1,181 @@
+export type SseWatchEventType =
+  | 'INITIAL'
+  | 'ADDED'
+  | 'MODIFIED'
+  | 'DELETED'
+  | 'ERROR'
+  | 'UPDATE';
+
+export interface SseWatchEvent {
+  type: SseWatchEventType;
+  object?: unknown;
+  items?: unknown[];
+  message?: string;
+}
+
+export interface SseMockOptions {
+  inferenceServices?: unknown[];
+  byNamespace?: Record<string, unknown[]>;
+}
+
+export class FakeEventSource {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 2;
+
+  readyState = FakeEventSource.OPEN;
+  onerror: ((event: Event) => void) | null = null;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+
+  constructor(public url: string, win: Window) {
+    const sources = getSseSources(win);
+    sources.push(this);
+
+    win.setTimeout(() => {
+      if (this.readyState === FakeEventSource.CLOSED) {
+        return;
+      }
+
+      this.onopen?.(new Event('open'));
+
+      if (isInferenceServiceListWatch(this.url)) {
+        const namespace = parseListWatchNamespace(this.url);
+        this.emit({
+          type: 'INITIAL',
+          items: getListItems(namespace),
+        });
+        return;
+      }
+
+      const detail = parseDetailWatch(this.url);
+      if (detail) {
+        const object = findService(detail.namespace, detail.name);
+        if (object) {
+          this.emit({
+            type: 'INITIAL',
+            object,
+          });
+        }
+      }
+    }, 0);
+  }
+
+  emit(event: SseWatchEvent) {
+    if (!this.onmessage || this.readyState === FakeEventSource.CLOSED) {
+      return;
+    }
+
+    this.onmessage(
+      new MessageEvent('message', {
+        data: JSON.stringify(event),
+      }),
+    );
+  }
+
+  close() {
+    this.readyState = FakeEventSource.CLOSED;
+  }
+
+  addEventListener() {}
+  removeEventListener() {}
+  dispatchEvent() {
+    return false;
+  }
+}
+
+export interface CypressSseWindow extends Window {
+  EventSource: typeof FakeEventSource;
+  __cypressSseSources: FakeEventSource[];
+}
+
+let sseMockOptions: SseMockOptions = { inferenceServices: [] };
+
+export function resetSseMock() {
+  sseMockOptions = { inferenceServices: [] };
+}
+
+export function setSseMockOptions(options: SseMockOptions = {}) {
+  sseMockOptions = {
+    inferenceServices: options.inferenceServices ?? [],
+    byNamespace: options.byNamespace,
+  };
+}
+
+export function installSseMock(win: Window) {
+  const sseWindow = win as CypressSseWindow;
+  sseWindow.__cypressSseSources = [];
+
+  class WindowEventSource extends FakeEventSource {
+    constructor(url: string) {
+      super(url, win);
+    }
+  }
+
+  sseWindow.EventSource = WindowEventSource;
+}
+
+export function emitSseOnWindow(
+  win: Window,
+  event: SseWatchEvent,
+  urlIncludes?: string,
+): number {
+  const openSources = getSseSources(win).filter(
+    source => source.readyState === FakeEventSource.OPEN,
+  );
+  const targets = urlIncludes
+    ? openSources.filter(source => source.url.includes(urlIncludes))
+    : openSources.filter(source => isInferenceServiceListWatch(source.url));
+
+  targets.forEach(source => source.emit(event));
+  return targets.length;
+}
+
+function getSseSources(win: Window): FakeEventSource[] {
+  const sseWindow = win as CypressSseWindow;
+  if (!sseWindow.__cypressSseSources) {
+    sseWindow.__cypressSseSources = [];
+  }
+  return sseWindow.__cypressSseSources;
+}
+
+function isInferenceServiceListWatch(url: string): boolean {
+  return /\/namespaces\/[^/]+\/inferenceservices\/?$/.test(url);
+}
+
+function parseListWatchNamespace(url: string): string | undefined {
+  const match = url.match(/\/namespaces\/([^/]+)\/inferenceservices\/?$/);
+  return match ? decodeURIComponent(match[1]) : undefined;
+}
+
+function parseDetailWatch(
+  url: string,
+): { namespace: string; name: string } | null {
+  const match = url.match(
+    /\/namespaces\/([^/]+)\/inferenceservices\/([^/?]+)\/?$/,
+  );
+  if (!match) {
+    return null;
+  }
+
+  return {
+    namespace: decodeURIComponent(match[1]),
+    name: decodeURIComponent(match[2]),
+  };
+}
+
+function getListItems(namespace?: string): unknown[] {
+  if (namespace && sseMockOptions.byNamespace?.[namespace]) {
+    return sseMockOptions.byNamespace[namespace];
+  }
+
+  return sseMockOptions.inferenceServices ?? [];
+}
+
+function findService(namespace: string, name: string): unknown | undefined {
+  const items = getListItems(namespace);
+  return items.find(item => {
+    const metadata = (item as { metadata?: { name?: string } }).metadata;
+    return metadata?.name === name;
+  });
+}

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -4,6 +4,8 @@ import { IndexComponent } from './pages/index/index.component';
 import { ServerInfoComponent } from './pages/server-info/server-info.component';
 import { SubmitFormComponent } from './pages/submit-form/submit-form.component';
 import { InferenceGraphComponent } from './pages/inference-graph/inference-graph.component';
+import { LLMInferenceServiceComponent } from './pages/llm-inference-service/llm-inference-service.component';
+import { LLMDetailsComponent } from './pages/llm-inference-service/llm-details/llm-details.component';
 import { GraphFormComponent } from './pages/inference-graph/graph-form/graph-form.component';
 import { GraphInfoComponent } from './pages/inference-graph/graph-info/graph-info.component';
 
@@ -12,6 +14,8 @@ const routes: Routes = [
   { path: 'details/:namespace/:name', component: ServerInfoComponent },
   { path: 'new', component: SubmitFormComponent },
   { path: 'inference-graphs', component: InferenceGraphComponent },
+  { path: 'llm-inference-services', component: LLMInferenceServiceComponent },
+  { path: 'llm-details/:namespace/:name', component: LLMDetailsComponent },
   { path: 'new-graph', component: GraphFormComponent },
   { path: 'edit-graph/:namespace/:name', component: GraphFormComponent },
   { path: 'graph-details/:namespace/:name', component: GraphInfoComponent },

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { KubeflowModule } from 'kubeflow';
 import { ServerInfoModule } from './pages/server-info/server-info.module';
 import { SubmitFormModule } from './pages/submit-form/submit-form.module';
 import { InferenceGraphModule } from './pages/inference-graph/inference-graph.module';
+import { LLMInferenceServiceModule } from './pages/llm-inference-service/llm-inference-service.module';
 import {
   MatSnackBarConfig,
   MAT_SNACK_BAR_DEFAULT_OPTIONS,
@@ -36,6 +37,7 @@ const MwaSnackBarConfig: MatSnackBarConfig = {
     ServerInfoModule,
     SubmitFormModule,
     InferenceGraphModule,
+    LLMInferenceServiceModule,
   ],
   providers: [
     { provide: MAT_SNACK_BAR_DEFAULT_OPTIONS, useValue: MwaSnackBarConfig },

--- a/frontend/src/app/pages/index/index.component.ts
+++ b/frontend/src/app/pages/index/index.component.ts
@@ -66,7 +66,20 @@ export class IndexComponent implements OnInit, OnDestroy {
     },
   });
 
-  buttons: ToolbarButton[] = [this.viewGraphsButton, this.newEndpointButton];
+  private viewLLMInferenceServicesButton = new ToolbarButton({
+    text: $localize`View LLMInferenceServices`,
+    icon: 'psychology',
+    stroked: true,
+    fn: () => {
+      this.router.navigate(['/llm-inference-services']);
+    },
+  });
+
+  buttons: ToolbarButton[] = [
+    this.viewLLMInferenceServicesButton,
+    this.viewGraphsButton,
+    this.newEndpointButton,
+  ];
 
   constructor(
     private backend: MWABackendService,

--- a/frontend/src/app/pages/llm-inference-service/config.ts
+++ b/frontend/src/app/pages/llm-inference-service/config.ts
@@ -1,0 +1,54 @@
+import {
+  PropertyValue,
+  StatusValue,
+  TableConfig,
+  LinkValue,
+  LinkType,
+} from 'kubeflow';
+
+/*
+ * Every column reads a precomputed property from the internal
+ * representation, so no parsing happens during change detection.
+ */
+export const defaultConfig: TableConfig = {
+  dynamicNamespaceColumn: true,
+  columns: [
+    {
+      matHeaderCellDef: $localize`Status`,
+      matColumnDef: 'status',
+      value: new StatusValue({ field: 'ui.status' }),
+    },
+    {
+      matHeaderCellDef: $localize`Name`,
+      matColumnDef: 'name',
+      value: new LinkValue({
+        field: 'ui.link',
+        truncate: true,
+        linkType: LinkType.Internal,
+      }),
+    },
+    {
+      matHeaderCellDef: $localize`Model`,
+      matColumnDef: 'model',
+      value: new PropertyValue({
+        field: 'ui.modelName',
+        truncate: true,
+      }),
+    },
+    {
+      matHeaderCellDef: $localize`Topology`,
+      matColumnDef: 'topology',
+      value: new PropertyValue({ field: 'ui.topology' }),
+    },
+    {
+      matHeaderCellDef: $localize`Parallelism`,
+      matColumnDef: 'parallelism',
+      value: new PropertyValue({ field: 'ui.parallelism' }),
+    },
+    {
+      matHeaderCellDef: $localize`Router`,
+      matColumnDef: 'router',
+      value: new PropertyValue({ field: 'ui.router' }),
+    },
+  ],
+};

--- a/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.html
+++ b/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.html
@@ -49,16 +49,25 @@
                 [date]="llmInferenceService.metadata?.creationTimestamp"
               ></lib-date-time>
             </lib-details-list-item>
-            <lib-details-list-item
-              key="URL"
-              *ngIf="llmInferenceService.status?.url"
-            >
+            <lib-details-list-item key="URL" *ngIf="serviceUrls.length > 0">
               <a
-                [href]="llmInferenceService.status.url"
+                [href]="serviceUrls[0].url"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                {{ llmInferenceService.status.url }}
+                {{ serviceUrls[0].url }}
+              </a>
+            </lib-details-list-item>
+            <lib-details-list-item
+              *ngFor="let endpoint of additionalServiceUrls"
+              [key]="endpoint.name || 'Address'"
+            >
+              <a
+                [href]="endpoint.url"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {{ endpoint.url }}
               </a>
             </lib-details-list-item>
             <lib-details-list-item
@@ -87,6 +96,21 @@
             </lib-details-list-item>
             <lib-details-list-item key="Scaling" *ngIf="scaling">
               {{ scaling }}
+            </lib-details-list-item>
+            <lib-details-list-item
+              key="Prefill replicas"
+              *ngIf="prefillReplicas !== undefined"
+            >
+              {{ prefillReplicas }}
+            </lib-details-list-item>
+            <lib-details-list-item
+              key="Prefill parallelism"
+              *ngIf="prefillParallelism"
+            >
+              {{ prefillParallelism }}
+            </lib-details-list-item>
+            <lib-details-list-item key="Prefill scaling" *ngIf="prefillScaling">
+              {{ prefillScaling }}
             </lib-details-list-item>
             <lib-details-list-item
               key="Base configurations"

--- a/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.html
+++ b/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.html
@@ -1,0 +1,171 @@
+<div class="lib-content-wrapper details-page">
+  <lib-title-actions-toolbar
+    title="LLMInferenceService details"
+    [backButton]="true"
+    (back)="navigateBack()"
+    class="margin-bottom"
+    i18n-title
+  >
+  </lib-title-actions-toolbar>
+
+  <div class="details-page-outer">
+    <lib-loading-spinner *ngIf="!detailsLoaded"></lib-loading-spinner>
+
+    <ng-container *ngIf="detailsLoaded">
+      <div class="details-page-inner">
+        <div class="details-page-inner-2">
+          <lib-status-icon
+            class="small-padding-right"
+            [phase]="status.phase"
+          ></lib-status-icon>
+          <div class="title">{{ serviceName }}</div>
+        </div>
+        <div class="small-padding-up">
+          <lib-status-info [status]="status"></lib-status-info>
+        </div>
+      </div>
+
+      <mat-tab-group
+        class="page-placement"
+        dynamicHeight
+        animationDuration="0ms"
+      >
+        <mat-tab label="OVERVIEW">
+          <div class="page-padding">
+            <lib-details-list-item key="Name">
+              {{ llmInferenceService.metadata?.name }}
+            </lib-details-list-item>
+            <lib-details-list-item key="Namespace">
+              {{ llmInferenceService.metadata?.namespace }}
+            </lib-details-list-item>
+            <lib-details-list-item key="Created">
+              <lib-date-time
+                [date]="llmInferenceService.metadata?.creationTimestamp"
+              ></lib-date-time>
+            </lib-details-list-item>
+            <lib-details-list-item
+              key="URL"
+              *ngIf="llmInferenceService.status?.url"
+            >
+              <a
+                [href]="llmInferenceService.status.url"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {{ llmInferenceService.status.url }}
+              </a>
+            </lib-details-list-item>
+            <lib-details-list-item
+              key="Model"
+              *ngIf="llmInferenceService.spec?.model?.name"
+            >
+              {{ llmInferenceService.spec.model.name }}
+            </lib-details-list-item>
+            <lib-details-list-item key="Model URI">
+              {{ llmInferenceService.spec?.model?.uri }}
+            </lib-details-list-item>
+            <lib-details-list-item key="Topology">
+              {{ topology }}
+            </lib-details-list-item>
+            <lib-details-list-item key="Parallelism" *ngIf="parallelism">
+              {{ parallelism }}
+            </lib-details-list-item>
+            <lib-details-list-item key="Router">
+              {{ router }}
+            </lib-details-list-item>
+            <lib-details-list-item
+              key="Replicas"
+              *ngIf="llmInferenceService.spec?.replicas !== undefined"
+            >
+              {{ llmInferenceService.spec.replicas }}
+            </lib-details-list-item>
+            <lib-details-list-item
+              key="Base configurations"
+              *ngIf="baseConfigurations.length > 0"
+            >
+              {{ baseConfigurations.join(', ') }}
+            </lib-details-list-item>
+            <lib-details-list-item
+              key="Applied configurations"
+              *ngIf="appliedConfigurations.length > 0"
+            >
+              {{ appliedConfigurations.join(', ') }}
+            </lib-details-list-item>
+
+            <h3 class="section-header">Conditions</h3>
+            <div *ngIf="conditions.length > 0" style="overflow-x: auto">
+              <table class="events-table">
+                <thead>
+                  <tr>
+                    <th style="width: 20%">Type</th>
+                    <th style="width: 10%">Status</th>
+                    <th style="width: 20%">Reason</th>
+                    <th style="width: 50%">Message</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr *ngFor="let condition of conditions">
+                    <td>{{ condition.type }}</td>
+                    <td>{{ condition.status }}</td>
+                    <td>{{ condition.reason }}</td>
+                    <td>{{ condition.message }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <div *ngIf="conditions.length === 0" class="no-events">
+              No conditions reported yet
+            </div>
+          </div>
+        </mat-tab>
+
+        <mat-tab label="EVENTS">
+          <div class="page-padding">
+            <div *ngIf="detailsLoaded">
+              <div *ngIf="events && events.length > 0" style="overflow-x: auto">
+                <table class="events-table">
+                  <thead>
+                    <tr>
+                      <th style="width: 10%">Type</th>
+                      <th style="width: 15%">Reason</th>
+                      <th style="width: 50%">Message</th>
+                      <th style="width: 25%">Last Timestamp</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr *ngFor="let event of events">
+                      <td>
+                        <span class="event-type-badge">
+                          {{ event.type }}
+                        </span>
+                      </td>
+                      <td>{{ event.reason }}</td>
+                      <td>{{ event.message }}</td>
+                      <td class="event-timestamp">
+                        {{ event.lastTimestamp }}
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <div *ngIf="!events || events.length === 0" class="no-events">
+                No events available
+              </div>
+            </div>
+          </div>
+        </mat-tab>
+
+        <mat-tab label="YAML">
+          <div class="yaml-container">
+            <pre *ngIf="detailsLoaded && yaml" class="yaml-content">{{
+              yaml
+            }}</pre>
+            <div *ngIf="detailsLoaded && !yaml" class="no-events">
+              No YAML content available
+            </div>
+          </div>
+        </mat-tab>
+      </mat-tab-group>
+    </ng-container>
+  </div>
+</div>

--- a/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.html
+++ b/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.html
@@ -9,7 +9,13 @@
   </lib-title-actions-toolbar>
 
   <div class="details-page-outer">
-    <lib-loading-spinner *ngIf="!detailsLoaded"></lib-loading-spinner>
+    <lib-loading-spinner
+      *ngIf="!detailsLoaded && !loadingErrorMessage"
+    ></lib-loading-spinner>
+
+    <div *ngIf="!detailsLoaded && loadingErrorMessage" class="no-events" i18n>
+      {{ loadingErrorMessage }}
+    </div>
 
     <ng-container *ngIf="detailsLoaded">
       <div class="details-page-inner">
@@ -78,6 +84,9 @@
               *ngIf="llmInferenceService.spec?.replicas !== undefined"
             >
               {{ llmInferenceService.spec.replicas }}
+            </lib-details-list-item>
+            <lib-details-list-item key="Scaling" *ngIf="scaling">
+              {{ scaling }}
             </lib-details-list-item>
             <lib-details-list-item
               key="Base configurations"

--- a/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.scss
+++ b/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.scss
@@ -1,0 +1,246 @@
+.details-page {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.details-page-outer {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
+}
+
+.details-page-inner {
+  padding: 16px;
+  border-bottom: 1px solid #e0e0e0;
+  flex-shrink: 0;
+}
+
+.details-page-inner-2 {
+  display: flex;
+  align-items: center;
+}
+
+.title {
+  font-size: 24px;
+  font-weight: 500;
+}
+
+.small-padding-right {
+  padding-right: 8px;
+}
+
+.small-padding-up {
+  padding-top: 8px;
+}
+
+.page-padding {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+
+.section-header {
+  margin-top: 32px;
+  margin-bottom: 16px;
+  font-size: 18px;
+  font-weight: 500;
+  color: #424242;
+}
+
+.node-section {
+  margin-bottom: 24px;
+  padding: 16px;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  background-color: #fafafa;
+}
+
+.node-section h4 {
+  margin: 0 0 12px 0;
+  font-size: 16px;
+  font-weight: 500;
+  color: #1976d2;
+}
+
+.step-item {
+  padding: 8px 0;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.step-item:last-child {
+  border-bottom: none;
+}
+
+.step-item strong {
+  display: inline-block;
+  min-width: 70px;
+  color: #424242;
+}
+
+.no-events {
+  padding: 24px;
+  text-align: center;
+  color: #757575;
+  font-style: italic;
+}
+
+.events-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  background-color: #fff;
+
+  thead {
+    background: linear-gradient(to bottom, #f8f9fa, #f3f4f6);
+    border-bottom: 2px solid #d0d7de;
+
+    th {
+      padding: 14px 16px;
+      text-align: left;
+      font-weight: 600;
+      color: #1f2937;
+      font-size: 13px;
+      letter-spacing: 0.5px;
+      border-right: 1px solid #e5e7eb;
+
+      &:last-child {
+        border-right: none;
+      }
+    }
+  }
+
+  tbody {
+    tr {
+      border-bottom: 1px solid #e5e7eb;
+      transition: all 0.2s ease;
+
+      &:hover {
+        background-color: #f9fafb;
+        box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.02);
+      }
+
+      &:last-child {
+        border-bottom: none;
+      }
+
+      td {
+        padding: 14px 16px;
+        color: #374151;
+        font-size: 13px;
+        line-height: 1.5;
+        border-right: 1px solid #e5e7eb;
+        word-break: break-word;
+        max-width: 300px;
+
+        &:last-child {
+          border-right: none;
+          max-width: none;
+        }
+
+        &:first-child {
+          font-weight: 500;
+          color: #0f172a;
+          min-width: 80px;
+        }
+      }
+    }
+
+    tr:nth-child(even) {
+      background-color: #fafbfc;
+    }
+  }
+}
+
+.page-placement {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  overflow-x: hidden;
+  min-height: 0;
+
+  ::ng-deep .mat-tab-body-wrapper {
+    height: 100% !important;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  ::ng-deep .mat-tab-body {
+    height: 100% !important;
+    overflow: auto !important;
+  }
+}
+
+.yaml-container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 0;
+}
+
+.yaml-content {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: auto;
+  background: #f8f9fa;
+  padding: 20px;
+  border-radius: 4px;
+  font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro',
+    monospace;
+  font-size: 14px;
+  line-height: 1.8;
+  color: #2d2d2d;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  border: 1px solid #d0d7de;
+  margin: 24px;
+
+  &::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: #f0f0f0;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: #b0b8c1;
+    border-radius: 4px;
+
+    &:hover {
+      background: #8c959f;
+    }
+  }
+}
+
+::ng-deep .mat-tab-body-content {
+  overflow-y: auto !important;
+  max-height: 100% !important;
+  display: block !important;
+}
+
+.event-type-badge {
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 4px;
+  background-color: #dbeafe;
+  color: #1e40af;
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.event-timestamp {
+  color: #6b7280;
+  font-size: 12px;
+}

--- a/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.spec.ts
+++ b/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.spec.ts
@@ -22,8 +22,19 @@ const mockLLMInferenceService: any = {
     replicas: 2,
     scaling: { minReplicas: 1, maxReplicas: 4, keda: {} },
     router: { ingress: {} },
+    parallelism: { tensor: 2 },
+    prefill: {
+      replicas: 3,
+      worker: {},
+      parallelism: { tensor: 4 },
+      scaling: { minReplicas: 1, maxReplicas: 6, keda: {} },
+    },
   },
   status: {
+    url: 'http://facebook-opt-125m.example.com',
+    addresses: [
+      { name: 'cluster', url: 'http://facebook-opt-125m.cluster.local' },
+    ],
     conditions: [
       {
         type: 'Ready',
@@ -111,9 +122,20 @@ describe('LLMDetailsComponent (Jest)', () => {
     expect(component.detailsLoaded).toBe(true);
     expect(component.loadingErrorMessage).toBe('');
     expect(component.status.phase).toBe(STATUS_TYPE.READY);
-    expect(component.topology).toBe('Single node');
+    expect(component.topology).toBe('Disaggregated multi-node');
     expect(component.router).toBe('ingress (managed)');
     expect(component.scaling).toBe('min=1, max=4, autoscaler=KEDA');
+    expect(component.parallelism).toBe('tensor=2');
+    expect(component.prefillReplicas).toBe(3);
+    expect(component.prefillParallelism).toBe('tensor=4');
+    expect(component.prefillScaling).toBe('min=1, max=6, autoscaler=KEDA');
+    expect(component.serviceUrls).toEqual([
+      { url: 'http://facebook-opt-125m.example.com' },
+      {
+        name: 'cluster',
+        url: 'http://facebook-opt-125m.cluster.local',
+      },
+    ]);
     expect(component.yaml).toContain('facebook-opt-125m');
     expect(component.events).toEqual([mockEvent]);
   });
@@ -124,6 +146,10 @@ describe('LLMDetailsComponent (Jest)', () => {
     const text = fixture.nativeElement.textContent;
     expect(text).toContain('facebook-opt-125m');
     expect(text).toContain('min=1, max=4, autoscaler=KEDA');
+    expect(text).toContain('http://facebook-opt-125m.example.com');
+    expect(text).toContain('http://facebook-opt-125m.cluster.local');
+    expect(text).toContain('tensor=4');
+    expect(text).toContain('min=1, max=6, autoscaler=KEDA');
   });
 
   it('should keep a recoverable state when the initial load fails', () => {
@@ -193,6 +219,36 @@ describe('LLMDetailsComponent (Jest)', () => {
     );
   });
 
+  it('should reset the view and ignore a stale response after the route changes', () => {
+    const firstResponse = new Subject<any>();
+    const secondService = {
+      ...mockLLMInferenceService,
+      metadata: {
+        ...mockLLMInferenceService.metadata,
+        name: 'another-service',
+      },
+    };
+
+    mockBackendService.getLLMInferenceService.mockReturnValue(
+      firstResponse.asObservable(),
+    );
+    emitRouteParameters();
+    expect(component.detailsLoaded).toBe(false);
+
+    mockBackendService.getLLMInferenceService.mockReturnValue(
+      of(secondService),
+    );
+    emitRouteParameters('kubeflow-user', 'another-service');
+    expect(component.detailsLoaded).toBe(true);
+    expect(component.llmInferenceService.metadata.name).toBe('another-service');
+
+    firstResponse.next(mockLLMInferenceService);
+    firstResponse.complete();
+    fixture.detectChanges();
+
+    expect(component.llmInferenceService.metadata.name).toBe('another-service');
+  });
+
   it('should navigate back to the list page', () => {
     component.navigateBack();
     expect(mockRouter.navigate).toHaveBeenCalledWith([
@@ -201,6 +257,10 @@ describe('LLMDetailsComponent (Jest)', () => {
   });
 
   it('should unsubscribe on destroy', () => {
+    const requestUnsubscribe = jest.spyOn(
+      component['requestSubscription'],
+      'unsubscribe',
+    );
     const pollingUnsubscribe = jest.spyOn(
       component['pollingSubscription'],
       'unsubscribe',
@@ -212,6 +272,7 @@ describe('LLMDetailsComponent (Jest)', () => {
 
     component.ngOnDestroy();
 
+    expect(requestUnsubscribe).toHaveBeenCalled();
     expect(pollingUnsubscribe).toHaveBeenCalled();
     expect(parametersUnsubscribe).toHaveBeenCalled();
   });

--- a/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.spec.ts
+++ b/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.spec.ts
@@ -1,0 +1,218 @@
+/// <reference types="jest" />
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { MatTabsModule } from '@angular/material/tabs';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ActivatedRoute, Router } from '@angular/router';
+import { NamespaceService, STATUS_TYPE } from 'kubeflow';
+import { MWABackendService } from 'src/app/services/backend.service';
+import { LLMDetailsComponent } from './llm-details.component';
+import { of, throwError, Subject } from 'rxjs';
+
+const mockLLMInferenceService: any = {
+  kind: 'LLMInferenceService',
+  apiVersion: 'serving.kserve.io/v1alpha1',
+  metadata: {
+    name: 'facebook-opt-125m',
+    namespace: 'kubeflow-user',
+    creationTimestamp: '2026-01-01T00:00:00Z',
+  },
+  spec: {
+    model: { uri: 'hf://facebook/opt-125m', name: 'facebook/opt-125m' },
+    replicas: 2,
+    scaling: { minReplicas: 1, maxReplicas: 4, keda: {} },
+    router: { ingress: {} },
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        lastTransitionTime: '2026-01-01T00:00:00Z',
+      },
+    ],
+  },
+};
+
+const mockEvent: any = {
+  type: 'Normal',
+  reason: 'Created',
+  message: 'Created workload',
+  lastTimestamp: '2026-01-01T00:00:00Z',
+};
+
+describe('LLMDetailsComponent (Jest)', () => {
+  let component: LLMDetailsComponent;
+  let fixture: ComponentFixture<LLMDetailsComponent>;
+  let mockBackendService: any;
+  let mockRouter: any;
+  let mockNamespaceService: any;
+  let routeParams: Subject<any>;
+
+  beforeEach(async () => {
+    routeParams = new Subject<any>();
+
+    mockBackendService = {
+      getLLMInferenceService: jest
+        .fn()
+        .mockReturnValue(of(mockLLMInferenceService)),
+      getLLMInferenceServiceEvents: jest.fn().mockReturnValue(of([mockEvent])),
+    };
+
+    mockNamespaceService = {
+      updateSelectedNamespace: jest.fn(),
+    };
+
+    mockRouter = {
+      navigate: jest.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      declarations: [LLMDetailsComponent],
+      imports: [HttpClientTestingModule, MatTabsModule, NoopAnimationsModule],
+      providers: [
+        { provide: MWABackendService, useValue: mockBackendService },
+        { provide: NamespaceService, useValue: mockNamespaceService },
+        { provide: Router, useValue: mockRouter },
+        {
+          provide: ActivatedRoute,
+          useValue: { params: routeParams.asObservable() },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LLMDetailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  const emitRouteParameters = (
+    namespace = 'kubeflow-user',
+    name = 'facebook-opt-125m',
+  ) => {
+    routeParams.next({ namespace, name });
+    fixture.detectChanges();
+  };
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load and parse the object on navigation', () => {
+    emitRouteParameters();
+
+    expect(mockNamespaceService.updateSelectedNamespace).toHaveBeenCalledWith(
+      'kubeflow-user',
+    );
+    expect(mockBackendService.getLLMInferenceService).toHaveBeenCalledWith(
+      'kubeflow-user',
+      'facebook-opt-125m',
+    );
+    expect(component.detailsLoaded).toBe(true);
+    expect(component.loadingErrorMessage).toBe('');
+    expect(component.status.phase).toBe(STATUS_TYPE.READY);
+    expect(component.topology).toBe('Single node');
+    expect(component.router).toBe('ingress (managed)');
+    expect(component.scaling).toBe('min=1, max=4, autoscaler=KEDA');
+    expect(component.yaml).toContain('facebook-opt-125m');
+    expect(component.events).toEqual([mockEvent]);
+  });
+
+  it('should render the fetched details', () => {
+    emitRouteParameters();
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('facebook-opt-125m');
+    expect(text).toContain('min=1, max=4, autoscaler=KEDA');
+  });
+
+  it('should keep a recoverable state when the initial load fails', () => {
+    mockBackendService.getLLMInferenceService.mockReturnValue(
+      throwError(() => new Error('backend unavailable')),
+    );
+
+    emitRouteParameters();
+
+    expect(component.detailsLoaded).toBe(false);
+    expect(component.loadingErrorMessage).toContain('Failed to load');
+    expect(fixture.nativeElement.textContent).toContain('Failed to load');
+  });
+
+  it('should recover when a later poll succeeds after an initial failure', () => {
+    mockBackendService.getLLMInferenceService.mockReturnValue(
+      throwError(() => new Error('backend unavailable')),
+    );
+    emitRouteParameters();
+    expect(component.detailsLoaded).toBe(false);
+
+    mockBackendService.getLLMInferenceService.mockReturnValue(
+      of(mockLLMInferenceService),
+    );
+    component['getBackendObjects']();
+    fixture.detectChanges();
+
+    expect(component.detailsLoaded).toBe(true);
+    expect(component.loadingErrorMessage).toBe('');
+  });
+
+  it('should keep showing loaded data when a later poll fails', () => {
+    emitRouteParameters();
+    expect(component.detailsLoaded).toBe(true);
+
+    mockBackendService.getLLMInferenceService.mockReturnValue(
+      throwError(() => new Error('backend unavailable')),
+    );
+    component['getBackendObjects']();
+    fixture.detectChanges();
+
+    expect(component.detailsLoaded).toBe(true);
+    expect(component.loadingErrorMessage).toBe('');
+  });
+
+  it('should tolerate an events request failure', () => {
+    mockBackendService.getLLMInferenceServiceEvents.mockReturnValue(
+      throwError(() => new Error('events unavailable')),
+    );
+
+    emitRouteParameters();
+
+    expect(component.detailsLoaded).toBe(true);
+    expect(component.events).toEqual([]);
+  });
+
+  it('should reload when the route parameters change', () => {
+    emitRouteParameters();
+    emitRouteParameters('kubeflow-user', 'another-service');
+
+    expect(mockNamespaceService.updateSelectedNamespace).toHaveBeenCalledTimes(
+      2,
+    );
+    expect(mockBackendService.getLLMInferenceService).toHaveBeenLastCalledWith(
+      'kubeflow-user',
+      'another-service',
+    );
+  });
+
+  it('should navigate back to the list page', () => {
+    component.navigateBack();
+    expect(mockRouter.navigate).toHaveBeenCalledWith([
+      '/llm-inference-services',
+    ]);
+  });
+
+  it('should unsubscribe on destroy', () => {
+    const pollingUnsubscribe = jest.spyOn(
+      component['pollingSubscription'],
+      'unsubscribe',
+    );
+    const parametersUnsubscribe = jest.spyOn(
+      component['paramsSubscription'],
+      'unsubscribe',
+    );
+
+    component.ngOnDestroy();
+
+    expect(pollingUnsubscribe).toHaveBeenCalled();
+    expect(parametersUnsubscribe).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.ts
+++ b/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.ts
@@ -1,0 +1,144 @@
+import { Component, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
+import { Subscription, of } from 'rxjs';
+import { switchMap, catchError } from 'rxjs/operators';
+import { Router, ActivatedRoute } from '@angular/router';
+import { dump } from 'js-yaml';
+import {
+  NamespaceService,
+  ExponentialBackoff,
+  Condition,
+  Status,
+} from 'kubeflow';
+import { MWABackendService } from 'src/app/services/backend.service';
+import { LLMInferenceServiceK8s } from 'src/app/types/kfserving/llm-inference-service';
+import {
+  appliedConfigurationNames,
+  baseConfigurationNames,
+  deriveTopology,
+  getLLMInferenceServiceStatus,
+  summarizeParallelism,
+  summarizeRouter,
+} from 'src/app/shared/llm-inference-service.utils';
+import { EventObject } from 'src/app/types/event';
+
+@Component({
+  selector: 'app-llm-details',
+  templateUrl: './llm-details.component.html',
+  styleUrls: ['./llm-details.component.scss'],
+})
+export class LLMDetailsComponent implements OnInit, OnDestroy {
+  public serviceName: string;
+  public namespace: string;
+  public detailsLoaded = false;
+  public llmInferenceService: LLMInferenceServiceK8s;
+  public status: Status;
+  public events: EventObject[] = [];
+
+  public topology = '';
+  public parallelism = '';
+  public router = '';
+  public conditions: Condition[] = [];
+  public baseConfigurations: string[] = [];
+  public appliedConfigurations: string[] = [];
+
+  private yamlData = '';
+
+  public get yaml(): string {
+    return this.yamlData;
+  }
+
+  private poller = new ExponentialBackoff({
+    interval: 4000,
+    maxInterval: 4001,
+    retries: 1,
+  });
+  private pollingSubscription = new Subscription();
+  private paramsSubscription = new Subscription();
+
+  constructor(
+    private route: ActivatedRoute,
+    private angularRouter: Router,
+    private namespaceService: NamespaceService,
+    private backend: MWABackendService,
+    private cdr: ChangeDetectorRef,
+  ) {}
+
+  ngOnInit() {
+    this.paramsSubscription = this.route.params.subscribe(params => {
+      this.namespaceService.updateSelectedNamespace(params.namespace);
+
+      this.serviceName = params.name;
+      this.namespace = params.namespace;
+
+      // Initial load before starting polling
+      this.getBackendObjects();
+
+      // Unsubscribe from previous polling before starting a new one
+      if (this.pollingSubscription) {
+        this.pollingSubscription.unsubscribe();
+      }
+
+      this.pollingSubscription = this.poller.start().subscribe(() => {
+        this.getBackendObjects();
+      });
+    });
+  }
+
+  ngOnDestroy() {
+    if (this.pollingSubscription) {
+      this.pollingSubscription.unsubscribe();
+    }
+    if (this.paramsSubscription) {
+      this.paramsSubscription.unsubscribe();
+    }
+  }
+
+  public navigateBack() {
+    this.angularRouter.navigate(['/llm-inference-services']);
+  }
+
+  private getBackendObjects() {
+    this.backend
+      .getLLMInferenceService(this.namespace, this.serviceName)
+      .pipe(
+        switchMap(llmInferenceService => {
+          this.llmInferenceService = llmInferenceService;
+          this.parseFetchedObject(llmInferenceService);
+          this.detailsLoaded = true;
+          this.cdr.detectChanges();
+          return this.backend
+            .getLLMInferenceServiceEvents(llmInferenceService)
+            .pipe(
+              catchError(err => {
+                console.warn('Could not load events:', err);
+                return of([]);
+              }),
+            );
+        }),
+      )
+      .subscribe({
+        next: events => {
+          this.events = events || [];
+          this.cdr.detectChanges();
+        },
+        error: err => {
+          console.error('Error loading the LLMInferenceService:', err);
+          this.detailsLoaded = true;
+          this.cdr.detectChanges();
+        },
+      });
+  }
+
+  private parseFetchedObject(llmInferenceService: LLMInferenceServiceK8s) {
+    const specification = llmInferenceService.spec;
+
+    this.status = getLLMInferenceServiceStatus(llmInferenceService);
+    this.topology = deriveTopology(specification);
+    this.parallelism = summarizeParallelism(specification);
+    this.router = summarizeRouter(specification);
+    this.conditions = llmInferenceService.status?.conditions || [];
+    this.baseConfigurations = baseConfigurationNames(specification);
+    this.appliedConfigurations = appliedConfigurationNames(llmInferenceService);
+    this.yamlData = dump(llmInferenceService);
+  }
+}

--- a/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.ts
+++ b/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy, ChangeDetectorRef } from '@angular/core';
-import { Subscription, of } from 'rxjs';
-import { switchMap, catchError } from 'rxjs/operators';
+import { EMPTY, Subscription, of } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
 import { Router, ActivatedRoute } from '@angular/router';
 import { dump } from 'js-yaml';
 import {
@@ -12,6 +12,7 @@ import {
 import { MWABackendService } from 'src/app/services/backend.service';
 import { LLMInferenceServiceK8s } from 'src/app/types/kfserving/llm-inference-service';
 import {
+  LLMInferenceServiceEndpoint,
   appliedConfigurationNames,
   baseConfigurationNames,
   deriveTopology,
@@ -19,6 +20,7 @@ import {
   summarizeParallelism,
   summarizeRouter,
   summarizeScaling,
+  uniqueServiceUrls,
 } from 'src/app/shared/llm-inference-service.utils';
 import { EventObject } from 'src/app/types/event';
 
@@ -40,6 +42,11 @@ export class LLMDetailsComponent implements OnInit, OnDestroy {
   public parallelism = '';
   public router = '';
   public scaling = '';
+  public prefillReplicas: number | undefined;
+  public prefillParallelism = '';
+  public prefillScaling = '';
+  public serviceUrls: LLMInferenceServiceEndpoint[] = [];
+  public additionalServiceUrls: LLMInferenceServiceEndpoint[] = [];
   public conditions: Condition[] = [];
   public baseConfigurations: string[] = [];
   public appliedConfigurations: string[] = [];
@@ -57,6 +64,7 @@ export class LLMDetailsComponent implements OnInit, OnDestroy {
   });
   private pollingSubscription = new Subscription();
   private paramsSubscription = new Subscription();
+  private requestSubscription = new Subscription();
 
   constructor(
     private route: ActivatedRoute,
@@ -72,14 +80,15 @@ export class LLMDetailsComponent implements OnInit, OnDestroy {
 
       this.serviceName = params.name;
       this.namespace = params.namespace;
-
-      // Initial load before starting polling
-      this.getBackendObjects();
+      this.resetView();
 
       // Unsubscribe from previous polling before starting a new one
       if (this.pollingSubscription) {
         this.pollingSubscription.unsubscribe();
       }
+
+      // Initial load before starting polling
+      this.getBackendObjects();
 
       this.pollingSubscription = this.poller.start().subscribe(() => {
         this.getBackendObjects();
@@ -88,6 +97,9 @@ export class LLMDetailsComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    if (this.requestSubscription) {
+      this.requestSubscription.unsubscribe();
+    }
     if (this.pollingSubscription) {
       this.pollingSubscription.unsubscribe();
     }
@@ -100,8 +112,33 @@ export class LLMDetailsComponent implements OnInit, OnDestroy {
     this.angularRouter.navigate(['/llm-inference-services']);
   }
 
+  private resetView() {
+    this.detailsLoaded = false;
+    this.loadingErrorMessage = '';
+    this.llmInferenceService = undefined;
+    this.events = [];
+    this.topology = '';
+    this.parallelism = '';
+    this.router = '';
+    this.scaling = '';
+    this.prefillReplicas = undefined;
+    this.prefillParallelism = '';
+    this.prefillScaling = '';
+    this.serviceUrls = [];
+    this.additionalServiceUrls = [];
+    this.conditions = [];
+    this.baseConfigurations = [];
+    this.appliedConfigurations = [];
+    this.yamlData = '';
+  }
+
   private getBackendObjects() {
-    this.backend
+    /*
+     * Replace the in-flight request so a slower response for a previous
+     * route or poll tick cannot overwrite the current service details.
+     */
+    this.requestSubscription.unsubscribe();
+    this.requestSubscription = this.backend
       .getLLMInferenceService(this.namespace, this.serviceName)
       .pipe(
         switchMap(llmInferenceService => {
@@ -119,13 +156,7 @@ export class LLMDetailsComponent implements OnInit, OnDestroy {
               }),
             );
         }),
-      )
-      .subscribe({
-        next: events => {
-          this.events = events || [];
-          this.cdr.detectChanges();
-        },
-        error: error => {
+        catchError(error => {
           console.error('Error loading the LLMInferenceService:', error);
           /*
            * Keep `detailsLoaded` untouched: the template dereferences the
@@ -138,18 +169,29 @@ export class LLMDetailsComponent implements OnInit, OnDestroy {
             this.loadingErrorMessage = $localize`Failed to load the LLMInferenceService. Retrying automatically.`;
           }
           this.cdr.detectChanges();
-        },
+          return EMPTY;
+        }),
+      )
+      .subscribe(events => {
+        this.events = events || [];
+        this.cdr.detectChanges();
       });
   }
 
   private parseFetchedObject(llmInferenceService: LLMInferenceServiceK8s) {
     const specification = llmInferenceService.spec;
+    const prefill = specification?.prefill;
 
     this.status = getLLMInferenceServiceStatus(llmInferenceService);
-    this.topology = deriveTopology(specification);
+    this.topology = deriveTopology(llmInferenceService);
     this.parallelism = summarizeParallelism(specification);
     this.router = summarizeRouter(specification);
     this.scaling = summarizeScaling(specification);
+    this.prefillReplicas = prefill?.replicas;
+    this.prefillParallelism = summarizeParallelism(prefill);
+    this.prefillScaling = summarizeScaling(prefill);
+    this.serviceUrls = uniqueServiceUrls(llmInferenceService.status);
+    this.additionalServiceUrls = this.serviceUrls.slice(1);
     this.conditions = llmInferenceService.status?.conditions || [];
     this.baseConfigurations = baseConfigurationNames(specification);
     this.appliedConfigurations = appliedConfigurationNames(llmInferenceService);

--- a/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.ts
+++ b/frontend/src/app/pages/llm-inference-service/llm-details/llm-details.component.ts
@@ -18,6 +18,7 @@ import {
   getLLMInferenceServiceStatus,
   summarizeParallelism,
   summarizeRouter,
+  summarizeScaling,
 } from 'src/app/shared/llm-inference-service.utils';
 import { EventObject } from 'src/app/types/event';
 
@@ -30,6 +31,7 @@ export class LLMDetailsComponent implements OnInit, OnDestroy {
   public serviceName: string;
   public namespace: string;
   public detailsLoaded = false;
+  public loadingErrorMessage = '';
   public llmInferenceService: LLMInferenceServiceK8s;
   public status: Status;
   public events: EventObject[] = [];
@@ -37,6 +39,7 @@ export class LLMDetailsComponent implements OnInit, OnDestroy {
   public topology = '';
   public parallelism = '';
   public router = '';
+  public scaling = '';
   public conditions: Condition[] = [];
   public baseConfigurations: string[] = [];
   public appliedConfigurations: string[] = [];
@@ -105,6 +108,7 @@ export class LLMDetailsComponent implements OnInit, OnDestroy {
           this.llmInferenceService = llmInferenceService;
           this.parseFetchedObject(llmInferenceService);
           this.detailsLoaded = true;
+          this.loadingErrorMessage = '';
           this.cdr.detectChanges();
           return this.backend
             .getLLMInferenceServiceEvents(llmInferenceService)
@@ -121,9 +125,18 @@ export class LLMDetailsComponent implements OnInit, OnDestroy {
           this.events = events || [];
           this.cdr.detectChanges();
         },
-        error: err => {
-          console.error('Error loading the LLMInferenceService:', err);
-          this.detailsLoaded = true;
+        error: error => {
+          console.error('Error loading the LLMInferenceService:', error);
+          /*
+           * Keep `detailsLoaded` untouched: the template dereferences the
+           * fetched object once the details are marked as loaded, so marking
+           * a failed initial load as loaded would crash the page. Polling
+           * keeps retrying, so a transient failure recovers on a later tick,
+           * and data that already rendered stays visible.
+           */
+          if (!this.detailsLoaded) {
+            this.loadingErrorMessage = $localize`Failed to load the LLMInferenceService. Retrying automatically.`;
+          }
           this.cdr.detectChanges();
         },
       });
@@ -136,6 +149,7 @@ export class LLMDetailsComponent implements OnInit, OnDestroy {
     this.topology = deriveTopology(specification);
     this.parallelism = summarizeParallelism(specification);
     this.router = summarizeRouter(specification);
+    this.scaling = summarizeScaling(specification);
     this.conditions = llmInferenceService.status?.conditions || [];
     this.baseConfigurations = baseConfigurationNames(specification);
     this.appliedConfigurations = appliedConfigurationNames(llmInferenceService);

--- a/frontend/src/app/pages/llm-inference-service/llm-inference-service.component.html
+++ b/frontend/src/app/pages/llm-inference-service/llm-inference-service.component.html
@@ -1,0 +1,24 @@
+<div class="lib-content-wrapper">
+  <lib-title-actions-toolbar
+    title="LLMInferenceServices"
+    [buttons]="buttons"
+    i18n-title
+  >
+    <!-- Standalone mode: use custom namespace selector when Kubeflow dashboard is not connected -->
+    <app-namespace-select
+      *ngIf="
+        (namespaceService.dashboardConnected$ | async) ===
+        dashboardDisconnectedState
+      "
+    ></app-namespace-select>
+  </lib-title-actions-toolbar>
+
+  <div class="page-padding lib-flex-grow lib-overflow-auto">
+    <lib-table
+      [config]="config"
+      [data]="llmInferenceServices"
+      [trackByFn]="llmInferenceServiceTrackByFn"
+      (actionsEmitter)="reactToAction($event)"
+    ></lib-table>
+  </div>
+</div>

--- a/frontend/src/app/pages/llm-inference-service/llm-inference-service.component.spec.ts
+++ b/frontend/src/app/pages/llm-inference-service/llm-inference-service.component.spec.ts
@@ -1,0 +1,207 @@
+/// <reference types="jest" />
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { RouterTestingModule } from '@angular/router/testing';
+import { MWABackendService } from 'src/app/services/backend.service';
+import { MWANamespaceService } from 'src/app/services/mwa-namespace.service';
+import {
+  NamespaceService,
+  SnackBarService,
+  PollerService,
+  STATUS_TYPE,
+  DashboardState,
+} from 'kubeflow';
+import { LLMInferenceServiceComponent } from './llm-inference-service.component';
+import { of } from 'rxjs';
+import { Router } from '@angular/router';
+
+const mockLLMInferenceService: any = {
+  kind: 'LLMInferenceService',
+  apiVersion: 'serving.kserve.io/v1alpha1',
+  metadata: {
+    name: 'facebook-opt-125m',
+    namespace: 'kubeflow-user',
+    creationTimestamp: '2026-01-01T00:00:00Z',
+  },
+  spec: {
+    model: { uri: 'hf://facebook/opt-125m', name: 'facebook/opt-125m' },
+    router: { gateway: {}, route: {}, scheduler: {} },
+    parallelism: { tensor: 2 },
+  },
+  status: {
+    conditions: [
+      {
+        type: 'Ready',
+        status: 'True',
+        lastTransitionTime: '2026-01-01T00:00:00Z',
+      },
+    ],
+  },
+};
+
+describe('LLMInferenceServiceComponent (Jest)', () => {
+  let component: LLMInferenceServiceComponent;
+  let fixture: ComponentFixture<LLMInferenceServiceComponent>;
+  let mockBackendService: any;
+  let mockRouter: any;
+  let mockSnackBar: any;
+  let mockPoller: any;
+  let mockNamespaceService: any;
+  let mockMWANamespaceService: any;
+
+  beforeEach(async () => {
+    mockBackendService = {
+      getLLMInferenceServices: jest
+        .fn()
+        .mockReturnValue(of([mockLLMInferenceService])),
+    };
+
+    mockNamespaceService = {
+      getSelectedNamespace: jest.fn().mockReturnValue(of('kubeflow-user')),
+      dashboardConnected$: of(DashboardState.Disconnected),
+    };
+
+    mockMWANamespaceService = {
+      initialize: jest.fn().mockReturnValue(of('')),
+      getSelectedNamespace: jest.fn().mockReturnValue(of('kubeflow-user')),
+      getNamespaceConfig$: jest.fn().mockReturnValue(
+        of({
+          namespaces: ['kubeflow-user'],
+          allowedNamespaces: ['kubeflow-user'],
+          isSingleNamespace: true,
+          autoSelectedNamespace: 'kubeflow-user',
+        }),
+      ),
+    };
+
+    mockSnackBar = {
+      open: jest.fn(),
+    };
+
+    mockPoller = {
+      exponential: jest.fn().mockReturnValue(of([mockLLMInferenceService])),
+    };
+
+    mockRouter = {
+      navigate: jest.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      declarations: [LLMInferenceServiceComponent],
+      imports: [
+        HttpClientTestingModule,
+        MatSnackBarModule,
+        RouterTestingModule,
+      ],
+      providers: [
+        { provide: MWABackendService, useValue: mockBackendService },
+        { provide: NamespaceService, useValue: mockNamespaceService },
+        { provide: MWANamespaceService, useValue: mockMWANamespaceService },
+        { provide: SnackBarService, useValue: mockSnackBar },
+        { provide: PollerService, useValue: mockPoller },
+        { provide: Router, useValue: mockRouter },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LLMInferenceServiceComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize with the selected namespace', () => {
+    expect(component.currentNamespace).toBe('kubeflow-user');
+  });
+
+  it('should have a toolbar button that navigates to the endpoints page', () => {
+    expect(component.buttons.length).toBe(1);
+    expect(component.buttons[0].text).toBe('View Endpoints');
+
+    component.buttons[0].fn();
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/']);
+  });
+
+  it('should poll for objects in the selected namespace', () => {
+    component.poll('kubeflow-user');
+    expect(mockBackendService.getLLMInferenceServices).toHaveBeenCalledWith(
+      'kubeflow-user',
+    );
+  });
+
+  it('should poll again when the namespace changes', () => {
+    component.poll('another-namespace');
+    expect(mockBackendService.getLLMInferenceServices).toHaveBeenCalledWith(
+      'another-namespace',
+    );
+  });
+
+  it('should process objects into the internal representation', () => {
+    component.poll('kubeflow-user');
+    fixture.detectChanges();
+
+    expect(component.llmInferenceServices.length).toBe(1);
+    const llmInferenceService = component.llmInferenceServices[0];
+    expect(llmInferenceService.ui?.status?.phase).toBe(STATUS_TYPE.READY);
+    expect(llmInferenceService.ui?.topology).toBe('Single node');
+    expect(llmInferenceService.ui?.parallelism).toBe('tensor=2');
+    expect(llmInferenceService.ui?.router).toBe(
+      'gateway (managed), route (managed), scheduler',
+    );
+    expect(llmInferenceService.ui?.modelName).toBe('facebook/opt-125m');
+    expect(llmInferenceService.ui?.link).toEqual({
+      text: 'facebook-opt-125m',
+      url: '/llm-details/kubeflow-user/facebook-opt-125m',
+    });
+  });
+
+  it('should block details navigation for terminating objects', () => {
+    const terminating: any = {
+      ...mockLLMInferenceService,
+      ui: {
+        status: { phase: STATUS_TYPE.TERMINATING, state: '', message: '' },
+      },
+    };
+    const mockEvent = {
+      stopPropagation: jest.fn(),
+      preventDefault: jest.fn(),
+    };
+
+    component.reactToAction({
+      action: 'name:link',
+      data: terminating,
+      event: mockEvent,
+    } as any);
+
+    expect(mockEvent.stopPropagation).toHaveBeenCalled();
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+    expect(mockSnackBar.open).toHaveBeenCalled();
+  });
+
+  it('should track objects by name and creation timestamp', () => {
+    const trackByResult = component.llmInferenceServiceTrackByFn(
+      0,
+      mockLLMInferenceService,
+    );
+    expect(trackByResult).toContain('facebook-opt-125m');
+  });
+
+  it('should unsubscribe on destroy', () => {
+    const namespaceUnsubscribe = jest.spyOn(
+      component['namespaceSubscription'],
+      'unsubscribe',
+    );
+    const pollingUnsubscribe = jest.spyOn(
+      component['pollingSubscription'],
+      'unsubscribe',
+    );
+
+    component.ngOnDestroy();
+
+    expect(namespaceUnsubscribe).toHaveBeenCalled();
+    expect(pollingUnsubscribe).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/pages/llm-inference-service/llm-inference-service.component.ts
+++ b/frontend/src/app/pages/llm-inference-service/llm-inference-service.component.ts
@@ -115,17 +115,17 @@ export class LLMInferenceServiceComponent implements OnInit, OnDestroy {
       });
   }
 
-  public reactToAction(a: ActionEvent) {
-    const llmInferenceService = a.data as LLMInferenceServiceIR;
+  public reactToAction(actionEvent: ActionEvent) {
+    const llmInferenceService = actionEvent.data as LLMInferenceServiceIR;
 
-    if (a.action === 'name:link') {
+    if (actionEvent.action === 'name:link') {
       /*
        * Do not allow the user to navigate to the details page of an
        * object that is being deleted.
        */
       if (llmInferenceService.ui?.status?.phase === STATUS_TYPE.TERMINATING) {
-        a.event?.stopPropagation();
-        a.event?.preventDefault();
+        actionEvent.event?.stopPropagation();
+        actionEvent.event?.preventDefault();
         const snackConfiguration: SnackBarConfig = {
           data: {
             msg: $localize`LLMInferenceService is being deleted, cannot show details.`,
@@ -156,7 +156,7 @@ export class LLMInferenceServiceComponent implements OnInit, OnDestroy {
 
     llmInferenceService.ui = {
       status: getLLMInferenceServiceStatus(llmInferenceService),
-      topology: deriveTopology(specification),
+      topology: deriveTopology(llmInferenceService),
       parallelism: summarizeParallelism(specification),
       router: summarizeRouter(specification),
       modelName: specification?.model?.name || specification?.model?.uri || '',

--- a/frontend/src/app/pages/llm-inference-service/llm-inference-service.component.ts
+++ b/frontend/src/app/pages/llm-inference-service/llm-inference-service.component.ts
@@ -1,0 +1,177 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { MWABackendService } from 'src/app/services/backend.service';
+import { MWANamespaceService } from 'src/app/services/mwa-namespace.service';
+import {
+  LLMInferenceServiceK8s,
+  LLMInferenceServiceIR,
+} from 'src/app/types/kfserving/llm-inference-service';
+import {
+  deriveTopology,
+  getLLMInferenceServiceStatus,
+  summarizeParallelism,
+  summarizeRouter,
+} from 'src/app/shared/llm-inference-service.utils';
+import { environment } from 'src/environments/environment';
+import {
+  NamespaceService,
+  STATUS_TYPE,
+  ActionEvent,
+  SnackBarService,
+  SnackType,
+  DashboardState,
+  ToolbarButton,
+  SnackBarConfig,
+  PollerService,
+} from 'kubeflow';
+import { Subscription } from 'rxjs';
+import { defaultConfig } from './config';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-llm-inference-service',
+  templateUrl: './llm-inference-service.component.html',
+})
+export class LLMInferenceServiceComponent implements OnInit, OnDestroy {
+  env = environment;
+
+  namespaceSubscription = new Subscription();
+  dashboardSubscription = new Subscription();
+  pollingSubscription = new Subscription();
+
+  currentNamespace: string | string[];
+  config = defaultConfig;
+  llmInferenceServices: LLMInferenceServiceIR[] = [];
+
+  dashboardDisconnectedState = DashboardState.Disconnected;
+
+  private viewEndpointsButton = new ToolbarButton({
+    text: $localize`View Endpoints`,
+    icon: 'cloud_upload',
+    stroked: true,
+    fn: () => {
+      this.router.navigate(['/']);
+    },
+  });
+
+  buttons: ToolbarButton[] = [this.viewEndpointsButton];
+
+  constructor(
+    private backend: MWABackendService,
+    private snack: SnackBarService,
+    private router: Router,
+    public namespaceService: NamespaceService,
+    public mwaNamespace: MWANamespaceService,
+    public poller: PollerService,
+  ) {}
+
+  ngOnInit(): void {
+    this.dashboardSubscription =
+      this.namespaceService.dashboardConnected$.subscribe(dashboardState => {
+        this.namespaceSubscription.unsubscribe();
+
+        if (dashboardState === DashboardState.Disconnected) {
+          // Standalone mode: use MWANamespaceService for namespace selection
+          this.namespaceSubscription = this.mwaNamespace
+            .getSelectedNamespace()
+            .subscribe(selectedNamespace => {
+              if (!selectedNamespace) {
+                return;
+              }
+              this.currentNamespace = selectedNamespace;
+              this.poll(selectedNamespace);
+            });
+          this.mwaNamespace.initialize().subscribe();
+        } else {
+          // Kubeflow mode: use the central dashboard NamespaceService
+          this.namespaceSubscription = this.namespaceService
+            .getSelectedNamespace()
+            .subscribe(selectedNamespace => {
+              if (!selectedNamespace) {
+                return;
+              }
+              this.currentNamespace = selectedNamespace;
+              this.poll(selectedNamespace);
+            });
+        }
+      });
+  }
+
+  ngOnDestroy() {
+    this.namespaceSubscription.unsubscribe();
+    this.dashboardSubscription.unsubscribe();
+    this.pollingSubscription.unsubscribe();
+  }
+
+  public poll(namespace: string | string[]) {
+    this.pollingSubscription.unsubscribe();
+    this.llmInferenceServices = [];
+
+    const request = this.backend.getLLMInferenceServices(namespace);
+
+    this.pollingSubscription = this.poller
+      .exponential(request)
+      .subscribe((services: LLMInferenceServiceK8s[]) => {
+        this.llmInferenceServices = this.processIncomingData(services);
+      });
+  }
+
+  public reactToAction(a: ActionEvent) {
+    const llmInferenceService = a.data as LLMInferenceServiceIR;
+
+    if (a.action === 'name:link') {
+      /*
+       * Do not allow the user to navigate to the details page of an
+       * object that is being deleted.
+       */
+      if (llmInferenceService.ui?.status?.phase === STATUS_TYPE.TERMINATING) {
+        a.event?.stopPropagation();
+        a.event?.preventDefault();
+        const snackConfiguration: SnackBarConfig = {
+          data: {
+            msg: $localize`LLMInferenceService is being deleted, cannot show details.`,
+            snackType: SnackType.Info,
+          },
+        };
+        this.snack.open(snackConfiguration);
+      }
+    }
+  }
+
+  // functions for converting the response objects to the
+  // internal representation objects
+  private processIncomingData(services: LLMInferenceServiceK8s[]) {
+    const servicesCopy: LLMInferenceServiceIR[] = JSON.parse(
+      JSON.stringify(services),
+    );
+
+    for (const llmInferenceService of servicesCopy) {
+      this.parseLLMInferenceService(llmInferenceService);
+    }
+
+    return servicesCopy;
+  }
+
+  private parseLLMInferenceService(llmInferenceService: LLMInferenceServiceIR) {
+    const specification = llmInferenceService.spec;
+
+    llmInferenceService.ui = {
+      status: getLLMInferenceServiceStatus(llmInferenceService),
+      topology: deriveTopology(specification),
+      parallelism: summarizeParallelism(specification),
+      router: summarizeRouter(specification),
+      modelName: specification?.model?.name || specification?.model?.uri || '',
+      link: {
+        text: llmInferenceService.metadata.name,
+        url: `/llm-details/${llmInferenceService.metadata.namespace}/${llmInferenceService.metadata.name}`,
+      },
+    };
+  }
+
+  // util functions
+  public llmInferenceServiceTrackByFn(
+    index: number,
+    llmInferenceService: LLMInferenceServiceK8s,
+  ) {
+    return `${llmInferenceService.metadata.name}/${llmInferenceService.metadata.creationTimestamp}`;
+  }
+}

--- a/frontend/src/app/pages/llm-inference-service/llm-inference-service.module.ts
+++ b/frontend/src/app/pages/llm-inference-service/llm-inference-service.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTabsModule } from '@angular/material/tabs';
+import { LLMInferenceServiceComponent } from './llm-inference-service.component';
+import { LLMDetailsComponent } from './llm-details/llm-details.component';
+import { KubeflowModule } from 'kubeflow';
+import { SharedModule } from '../../shared/shared.module';
+
+@NgModule({
+  declarations: [LLMInferenceServiceComponent, LLMDetailsComponent],
+  imports: [CommonModule, KubeflowModule, MatTabsModule, SharedModule],
+  exports: [LLMInferenceServiceComponent, LLMDetailsComponent],
+})
+export class LLMInferenceServiceModule {}

--- a/frontend/src/app/services/backend.service.ts
+++ b/frontend/src/app/services/backend.service.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { InferenceServiceK8s } from '../types/kfserving/v1beta1';
 import { InferenceGraphK8s } from '../types/kfserving/v1alpha1';
+import { LLMInferenceServiceK8s } from '../types/kfserving/llm-inference-service';
 import {
   MWABackendResponse,
   InferenceServiceLogs,
@@ -125,6 +126,68 @@ export class MWABackendService extends BackendService {
     const name = inferenceGraph.metadata!.name;
     const namespace = inferenceGraph.metadata!.namespace;
     const url = `api/namespaces/${namespace}/inferencegraphs/${name}/events`;
+
+    return this.http.get<MWABackendResponse>(url).pipe(
+      catchError(error => this.handleError(error, false)),
+      map((resp: MWABackendResponse) => resp.events),
+    );
+  }
+
+  /*
+   * LLMInferenceService GETters
+   */
+  public getLLMInferenceService(
+    namespace: string,
+    name: string,
+  ): Observable<LLMInferenceServiceK8s> {
+    const url = `api/namespaces/${namespace}/llminferenceservices/${name}`;
+
+    return this.http.get<MWABackendResponse>(url).pipe(
+      catchError(error => this.handleError(error)),
+      map((resp: MWABackendResponse) => {
+        return resp.llmInferenceService;
+      }),
+    );
+  }
+
+  private getLLMInferenceServicesSingleNamespace(
+    namespace: string,
+  ): Observable<LLMInferenceServiceK8s[]> {
+    const url = `api/namespaces/${namespace}/llminferenceservices`;
+
+    return this.http.get<MWABackendResponse>(url).pipe(
+      catchError(error => this.handleError(error)),
+      map((resp: MWABackendResponse) => {
+        return resp.llmInferenceServices;
+      }),
+    );
+  }
+
+  private getLLMInferenceServicesAllNamespaces(
+    namespaces: string[],
+  ): Observable<LLMInferenceServiceK8s[]> {
+    return this.getObjectsAllNamespaces(
+      this.getLLMInferenceServicesSingleNamespace.bind(this),
+      namespaces,
+    );
+  }
+
+  public getLLMInferenceServices(
+    namespace: string | string[],
+  ): Observable<LLMInferenceServiceK8s[]> {
+    if (Array.isArray(namespace)) {
+      return this.getLLMInferenceServicesAllNamespaces(namespace);
+    }
+
+    return this.getLLMInferenceServicesSingleNamespace(namespace);
+  }
+
+  public getLLMInferenceServiceEvents(
+    llmInferenceService: LLMInferenceServiceK8s,
+  ): Observable<EventObject[]> {
+    const name = llmInferenceService.metadata!.name;
+    const namespace = llmInferenceService.metadata!.namespace;
+    const url = `api/namespaces/${namespace}/llminferenceservices/${name}/events`;
 
     return this.http.get<MWABackendResponse>(url).pipe(
       catchError(error => this.handleError(error, false)),

--- a/frontend/src/app/shared/llm-inference-service.utils.spec.ts
+++ b/frontend/src/app/shared/llm-inference-service.utils.spec.ts
@@ -7,6 +7,7 @@ import {
   getLLMInferenceServiceStatus,
   summarizeParallelism,
   summarizeRouter,
+  summarizeScaling,
 } from './llm-inference-service.utils';
 import { LLMInferenceServiceK8s } from '../types/kfserving/llm-inference-service';
 
@@ -111,6 +112,15 @@ describe('summarizeParallelism', () => {
       }),
     ).toBe('pipeline=0');
   });
+
+  it('includes the data parallelism RPC port', () => {
+    expect(
+      summarizeParallelism({
+        model: { uri: 'hf://a/b' },
+        parallelism: { data: 4, dataRPCPort: 5555 },
+      }),
+    ).toBe('data=4, data-rpc-port=5555');
+  });
 });
 
 describe('summarizeRouter', () => {
@@ -124,13 +134,65 @@ describe('summarizeRouter', () => {
     );
   });
 
-  it('lists the requested router components', () => {
+  it('labels empty component objects as managed', () => {
     expect(
       summarizeRouter({
         model: { uri: 'hf://a/b' },
         router: { gateway: {}, route: {}, scheduler: {} },
       }),
-    ).toBe('gateway, route, scheduler');
+    ).toBe('gateway (managed), route (managed), scheduler');
+  });
+
+  it('labels components with references as referenced', () => {
+    expect(
+      summarizeRouter({
+        model: { uri: 'hf://a/b' },
+        router: {
+          gateway: { refs: [{ name: 'shared-gateway' }] },
+          route: { http: { refs: [{ name: 'shared-route' }] } },
+        },
+      }),
+    ).toBe('gateway (referenced), route (referenced)');
+  });
+
+  it('summarizes an ingress-only router instead of reporting the default', () => {
+    expect(
+      summarizeRouter({
+        model: { uri: 'hf://a/b' },
+        router: { ingress: {} },
+      }),
+    ).toBe('ingress (managed)');
+
+    expect(
+      summarizeRouter({
+        model: { uri: 'hf://a/b' },
+        router: { ingress: { refs: [{ name: 'shared-ingress' }] } },
+      }),
+    ).toBe('ingress (referenced)');
+  });
+});
+
+describe('summarizeScaling', () => {
+  it('returns an empty string when scaling is not configured', () => {
+    expect(summarizeScaling(minimalWithoutRouter.spec)).toBe('');
+  });
+
+  it('summarizes the replica bounds and the requested autoscaler', () => {
+    expect(
+      summarizeScaling({
+        model: { uri: 'hf://a/b' },
+        scaling: { minReplicas: 1, maxReplicas: 4, keda: {} },
+      }),
+    ).toBe('min=1, max=4, autoscaler=KEDA');
+  });
+
+  it('summarizes the workload variant autoscaler', () => {
+    expect(
+      summarizeScaling({
+        model: { uri: 'hf://a/b' },
+        scaling: { maxReplicas: 8, wva: {} },
+      }),
+    ).toBe('max=8, autoscaler=workload variant autoscaler');
   });
 });
 

--- a/frontend/src/app/shared/llm-inference-service.utils.spec.ts
+++ b/frontend/src/app/shared/llm-inference-service.utils.spec.ts
@@ -8,8 +8,12 @@ import {
   summarizeParallelism,
   summarizeRouter,
   summarizeScaling,
+  uniqueServiceUrls,
 } from './llm-inference-service.utils';
-import { LLMInferenceServiceK8s } from '../types/kfserving/llm-inference-service';
+import {
+  LLMInferenceServiceK8s,
+  LLMInferenceServiceSpec,
+} from '../types/kfserving/llm-inference-service';
 
 /*
  * The first two objects mirror real resources observed on a live cluster:
@@ -51,41 +55,110 @@ const withBaseConfiguration: LLMInferenceServiceK8s = {
   status: { conditions: [] },
 };
 
+const fromSpec = (spec?: LLMInferenceServiceSpec): LLMInferenceServiceK8s => ({
+  spec,
+});
+
 describe('deriveTopology', () => {
   it('labels a specification with only a template as single node', () => {
-    expect(deriveTopology({ model: { uri: 'hf://a/b' }, template: {} })).toBe(
-      'Single node',
-    );
+    expect(
+      deriveTopology(fromSpec({ model: { uri: 'hf://a/b' }, template: {} })),
+    ).toBe('Single node');
   });
 
   it('labels a worker specification as multi-node', () => {
     expect(
-      deriveTopology({ model: { uri: 'hf://a/b' }, template: {}, worker: {} }),
+      deriveTopology(
+        fromSpec({ model: { uri: 'hf://a/b' }, template: {}, worker: {} }),
+      ),
     ).toBe('Multi-node');
   });
 
   it('labels a prefill specification as disaggregated', () => {
     expect(
-      deriveTopology({ model: { uri: 'hf://a/b' }, template: {}, prefill: {} }),
+      deriveTopology(
+        fromSpec({ model: { uri: 'hf://a/b' }, template: {}, prefill: {} }),
+      ),
     ).toBe('Disaggregated');
   });
 
   it('labels worker plus prefill as disaggregated multi-node', () => {
     expect(
-      deriveTopology({
-        model: { uri: 'hf://a/b' },
-        template: {},
-        worker: {},
-        prefill: {},
-      }),
+      deriveTopology(
+        fromSpec({
+          model: { uri: 'hf://a/b' },
+          template: {},
+          worker: {},
+          prefill: {},
+        }),
+      ),
+    ).toBe('Disaggregated multi-node');
+  });
+
+  it('labels a prefill workload with its own worker as disaggregated multi-node', () => {
+    expect(
+      deriveTopology(
+        fromSpec({
+          model: { uri: 'hf://a/b' },
+          template: {},
+          prefill: { worker: {} },
+        }),
+      ),
     ).toBe('Disaggregated multi-node');
   });
 
   it('labels an empty workload specification as single node, because absence means the controller default', () => {
-    expect(deriveTopology(minimalWithoutRouter.spec)).toBe('Single node');
+    expect(deriveTopology(minimalWithoutRouter)).toBe('Single node');
   });
 
-  it('tolerates a missing specification', () => {
+  it('does not guess single-node when the specification only references a base configuration', () => {
+    expect(deriveTopology(withBaseConfiguration)).toBe('From configuration');
+  });
+
+  it('uses observed workloads when the local specification delegates topology', () => {
+    expect(
+      deriveTopology({
+        spec: {
+          model: { uri: 'hf://a/b' },
+          baseRefs: [{ name: 'sample-disaggregated-configuration' }],
+        },
+        status: {
+          workloads: {
+            primary: {
+              apiGroup: 'apps',
+              kind: 'Deployment',
+              name: 'decode',
+            },
+            prefill: {
+              apiGroup: 'apps',
+              kind: 'Deployment',
+              name: 'prefill',
+            },
+          },
+        },
+      }),
+    ).toBe('Disaggregated');
+
+    expect(
+      deriveTopology({
+        spec: {
+          model: { uri: 'hf://a/b' },
+          baseRefs: [{ name: 'sample-multi-node-configuration' }],
+        },
+        status: {
+          workloads: {
+            primary: {
+              apiGroup: 'leaderworkerset.x-k8s.io',
+              kind: 'LeaderWorkerSet',
+              name: 'decode',
+            },
+          },
+        },
+      }),
+    ).toBe('Multi-node');
+  });
+
+  it('tolerates a missing object', () => {
     expect(deriveTopology(undefined)).toBe('Single node');
   });
 });
@@ -120,6 +193,14 @@ describe('summarizeParallelism', () => {
         parallelism: { data: 4, dataRPCPort: 5555 },
       }),
     ).toBe('data=4, data-rpc-port=5555');
+  });
+
+  it('summarizes nested prefill parallelism independently of decode', () => {
+    expect(
+      summarizeParallelism({
+        parallelism: { tensor: 4 },
+      }),
+    ).toBe('tensor=4');
   });
 });
 
@@ -193,6 +274,37 @@ describe('summarizeScaling', () => {
         scaling: { maxReplicas: 8, wva: {} },
       }),
     ).toBe('max=8, autoscaler=workload variant autoscaler');
+  });
+
+  it('summarizes nested prefill scaling independently of decode', () => {
+    expect(
+      summarizeScaling({
+        scaling: { minReplicas: 2, maxReplicas: 6, keda: {} },
+      }),
+    ).toBe('min=2, max=6, autoscaler=KEDA');
+  });
+});
+
+describe('uniqueServiceUrls', () => {
+  it('returns an empty list when no addresses are reported', () => {
+    expect(uniqueServiceUrls(undefined)).toEqual([]);
+    expect(uniqueServiceUrls({})).toEqual([]);
+  });
+
+  it('keeps the primary URL first and drops duplicates from addresses', () => {
+    expect(
+      uniqueServiceUrls({
+        url: 'http://llm.example.com',
+        address: { url: 'http://llm.example.com' },
+        addresses: [
+          { name: 'public', url: 'http://llm.example.com' },
+          { name: 'cluster', url: 'http://llm.cluster.local' },
+        ],
+      }),
+    ).toEqual([
+      { url: 'http://llm.example.com' },
+      { name: 'cluster', url: 'http://llm.cluster.local' },
+    ]);
   });
 });
 
@@ -270,6 +382,25 @@ describe('getLLMInferenceServiceStatus', () => {
     expect(status.phase).toBe(STATUS_TYPE.WARNING);
     expect(status.message).toBe(
       'MainWorkloadNotReady: waiting for the deployment to become available',
+    );
+  });
+
+  it('omits an undefined reason when a failed condition only has a message', () => {
+    const status = getLLMInferenceServiceStatus({
+      metadata: { name: 'message-only' },
+      status: {
+        conditions: [
+          {
+            type: 'WorkloadsReady',
+            status: 'False',
+            message: 'waiting for the deployment to become available',
+          },
+        ],
+      },
+    });
+    expect(status.phase).toBe(STATUS_TYPE.WARNING);
+    expect(status.message).toBe(
+      'waiting for the deployment to become available',
     );
   });
 

--- a/frontend/src/app/shared/llm-inference-service.utils.spec.ts
+++ b/frontend/src/app/shared/llm-inference-service.utils.spec.ts
@@ -1,0 +1,256 @@
+import { STATUS_TYPE } from 'kubeflow';
+import {
+  appliedConfigurationNames,
+  baseConfigurationNames,
+  deriveTopology,
+  findCondition,
+  getLLMInferenceServiceStatus,
+  summarizeParallelism,
+  summarizeRouter,
+} from './llm-inference-service.utils';
+import { LLMInferenceServiceK8s } from '../types/kfserving/llm-inference-service';
+
+/*
+ * The first two objects mirror real resources observed on a live cluster:
+ * a minimal specification that delegates everything to the controller
+ * presets, and a specification that references a base configuration. Both
+ * sat at Ready Unknown because the cluster lacked the preset
+ * configurations, which is a state the user interface must render.
+ */
+
+const minimalWithoutRouter: LLMInferenceServiceK8s = {
+  apiVersion: 'serving.kserve.io/v1alpha2',
+  kind: 'LLMInferenceService',
+  metadata: { name: 'sample-minimal-without-router' },
+  spec: {
+    model: { uri: 'hf://facebook/opt-125m', name: 'facebook/opt-125m' },
+  },
+  status: {
+    conditions: [
+      {
+        type: 'PresetsCombined',
+        status: 'False',
+        reason: 'ConfigNotFound',
+        message:
+          'LLMInferenceServiceConfig "kserve-config-llm-router-route" not found',
+      },
+      { type: 'Ready', status: 'Unknown', reason: 'NewObservedGenFailure' },
+    ],
+  },
+};
+
+const withBaseConfiguration: LLMInferenceServiceK8s = {
+  apiVersion: 'serving.kserve.io/v1alpha2',
+  kind: 'LLMInferenceService',
+  metadata: { name: 'sample-facebook-opt-125m' },
+  spec: {
+    baseRefs: [{ name: 'sample-single-node-configuration' }],
+    model: { uri: 'hf://facebook/opt-125m' },
+  },
+  status: { conditions: [] },
+};
+
+describe('deriveTopology', () => {
+  it('labels a specification with only a template as single node', () => {
+    expect(deriveTopology({ model: { uri: 'hf://a/b' }, template: {} })).toBe(
+      'Single node',
+    );
+  });
+
+  it('labels a worker specification as multi-node', () => {
+    expect(
+      deriveTopology({ model: { uri: 'hf://a/b' }, template: {}, worker: {} }),
+    ).toBe('Multi-node');
+  });
+
+  it('labels a prefill specification as disaggregated', () => {
+    expect(
+      deriveTopology({ model: { uri: 'hf://a/b' }, template: {}, prefill: {} }),
+    ).toBe('Disaggregated');
+  });
+
+  it('labels worker plus prefill as disaggregated multi-node', () => {
+    expect(
+      deriveTopology({
+        model: { uri: 'hf://a/b' },
+        template: {},
+        worker: {},
+        prefill: {},
+      }),
+    ).toBe('Disaggregated multi-node');
+  });
+
+  it('labels an empty workload specification as single node, because absence means the controller default', () => {
+    expect(deriveTopology(minimalWithoutRouter.spec)).toBe('Single node');
+  });
+
+  it('tolerates a missing specification', () => {
+    expect(deriveTopology(undefined)).toBe('Single node');
+  });
+});
+
+describe('summarizeParallelism', () => {
+  it('returns an empty string when parallelism is not configured', () => {
+    expect(summarizeParallelism(minimalWithoutRouter.spec)).toBe('');
+  });
+
+  it('lists the configured dimensions in a stable order', () => {
+    expect(
+      summarizeParallelism({
+        model: { uri: 'hf://a/b' },
+        parallelism: { tensor: 2, data: 4, expert: true },
+      }),
+    ).toBe('tensor=2, data=4, expert');
+  });
+
+  it('includes a zero value instead of dropping it', () => {
+    expect(
+      summarizeParallelism({
+        model: { uri: 'hf://a/b' },
+        parallelism: { pipeline: 0 },
+      }),
+    ).toBe('pipeline=0');
+  });
+});
+
+describe('summarizeRouter', () => {
+  it('reports the controller default when the router block is absent', () => {
+    expect(summarizeRouter(minimalWithoutRouter.spec)).toBe('default');
+  });
+
+  it('reports the controller default for an empty router block', () => {
+    expect(summarizeRouter({ model: { uri: 'hf://a/b' }, router: {} })).toBe(
+      'default',
+    );
+  });
+
+  it('lists the requested router components', () => {
+    expect(
+      summarizeRouter({
+        model: { uri: 'hf://a/b' },
+        router: { gateway: {}, route: {}, scheduler: {} },
+      }),
+    ).toBe('gateway, route, scheduler');
+  });
+});
+
+describe('findCondition', () => {
+  it('finds the Ready condition on a real-world status', () => {
+    const ready = findCondition(minimalWithoutRouter, 'Ready');
+    expect(ready?.status).toBe('Unknown');
+    expect(ready?.reason).toBe('NewObservedGenFailure');
+  });
+
+  it('returns null when the condition type is absent', () => {
+    expect(findCondition(withBaseConfiguration, 'Ready')).toBeNull();
+  });
+
+  it('returns null when the object has no status yet', () => {
+    expect(findCondition({ metadata: { name: 'new' } }, 'Ready')).toBeNull();
+  });
+});
+
+describe('appliedConfigurationNames', () => {
+  it('accepts entries carrying a plain name field', () => {
+    expect(
+      appliedConfigurationNames({
+        status: { appliedConfigs: [{ name: 'kserve-config-llm-template' }] },
+      }),
+    ).toEqual(['kserve-config-llm-template']);
+  });
+
+  it('accepts entries shaped as full objects with metadata', () => {
+    expect(
+      appliedConfigurationNames({
+        status: {
+          appliedConfigs: [{ metadata: { name: 'kserve-config-llm-router' } }],
+        },
+      }),
+    ).toEqual(['kserve-config-llm-router']);
+  });
+
+  it('returns an empty list when the controller reports nothing', () => {
+    expect(appliedConfigurationNames(minimalWithoutRouter)).toEqual([]);
+  });
+});
+
+describe('getLLMInferenceServiceStatus', () => {
+  it('surfaces the failed condition message on the real-world fixture', () => {
+    const status = getLLMInferenceServiceStatus(minimalWithoutRouter);
+    expect(status.phase).toBe(STATUS_TYPE.WARNING);
+    expect(status.message).toContain('ConfigNotFound');
+    expect(status.message).toContain('kserve-config-llm-router-route');
+  });
+
+  it('reports ready when the Ready condition is true', () => {
+    const status = getLLMInferenceServiceStatus({
+      metadata: { name: 'healthy' },
+      status: { conditions: [{ type: 'Ready', status: 'True' }] },
+    });
+    expect(status.phase).toBe(STATUS_TYPE.READY);
+  });
+
+  it('prefers a failed condition message over a vague unknown readiness', () => {
+    const status = getLLMInferenceServiceStatus({
+      metadata: { name: 'failing' },
+      status: {
+        conditions: [
+          { type: 'Ready', status: 'Unknown', reason: 'Progressing' },
+          {
+            type: 'WorkloadsReady',
+            status: 'False',
+            reason: 'MainWorkloadNotReady',
+            message: 'waiting for the deployment to become available',
+          },
+        ],
+      },
+    });
+    expect(status.phase).toBe(STATUS_TYPE.WARNING);
+    expect(status.message).toBe(
+      'MainWorkloadNotReady: waiting for the deployment to become available',
+    );
+  });
+
+  it('waits when nothing failed and readiness is still unknown', () => {
+    const status = getLLMInferenceServiceStatus({
+      metadata: { name: 'progressing' },
+      status: {
+        conditions: [
+          { type: 'Ready', status: 'Unknown', reason: 'Progressing' },
+        ],
+      },
+    });
+    expect(status.phase).toBe(STATUS_TYPE.WAITING);
+    expect(status.message).toBe('Progressing');
+  });
+
+  it('warns when the object reports no conditions yet', () => {
+    const status = getLLMInferenceServiceStatus({
+      metadata: { name: 'brand-new' },
+    });
+    expect(status.phase).toBe(STATUS_TYPE.WARNING);
+  });
+
+  it('reports terminating when a deletion timestamp is present', () => {
+    const status = getLLMInferenceServiceStatus({
+      metadata: {
+        name: 'going-away',
+        deletionTimestamp: new Date('2026-08-05T12:00:00Z'),
+      },
+      status: { conditions: [{ type: 'Ready', status: 'True' }] },
+    });
+    expect(status.phase).toBe(STATUS_TYPE.TERMINATING);
+  });
+});
+
+describe('baseConfigurationNames', () => {
+  it('returns the referenced configuration names in order', () => {
+    expect(baseConfigurationNames(withBaseConfiguration.spec)).toEqual([
+      'sample-single-node-configuration',
+    ]);
+  });
+
+  it('returns an empty list when nothing is referenced', () => {
+    expect(baseConfigurationNames(minimalWithoutRouter.spec)).toEqual([]);
+  });
+});

--- a/frontend/src/app/shared/llm-inference-service.utils.ts
+++ b/frontend/src/app/shared/llm-inference-service.utils.ts
@@ -68,6 +68,9 @@ export function summarizeParallelism(spec?: LLMInferenceServiceSpec): string {
   if (parallelism.pipeline !== undefined) {
     parts.push(`pipeline=${parallelism.pipeline}`);
   }
+  if (parallelism.dataRPCPort !== undefined) {
+    parts.push(`data-rpc-port=${parallelism.dataRPCPort}`);
+  }
   if (parallelism.expert) {
     parts.push('expert');
   }
@@ -75,9 +78,16 @@ export function summarizeParallelism(spec?: LLMInferenceServiceSpec): string {
 }
 
 /**
- * Summarize which router components the specification requests, for
- * example "gateway, route, scheduler". Returns "default" when the
- * specification leaves routing entirely to the controller presets.
+ * Summarize the requested router mode, for example
+ * "gateway (managed), route (managed), scheduler". Returns "default" when
+ * the specification leaves routing entirely to the controller presets.
+ *
+ * Both API versions share the same convention: an empty component object
+ * requests a controller-managed resource, while a `refs` list points at
+ * existing resources the user manages themselves. The route component
+ * nests its references under `http.refs`. The scheduler has no managed
+ * versus referenced distinction; its presence enables the inference
+ * gateway extension.
  */
 export function summarizeRouter(spec?: LLMInferenceServiceSpec): string {
   const router = spec?.router;
@@ -85,17 +95,56 @@ export function summarizeRouter(spec?: LLMInferenceServiceSpec): string {
     return 'default';
   }
 
+  const describeComponent = (name: string, hasReferences: boolean) =>
+    hasReferences ? `${name} (referenced)` : `${name} (managed)`;
+
   const parts: string[] = [];
   if (router.gateway) {
-    parts.push('gateway');
+    parts.push(
+      describeComponent('gateway', (router.gateway.refs || []).length > 0),
+    );
   }
   if (router.route) {
-    parts.push('route');
+    parts.push(
+      describeComponent('route', (router.route.http?.refs || []).length > 0),
+    );
+  }
+  if (router.ingress) {
+    parts.push(
+      describeComponent('ingress', (router.ingress.refs || []).length > 0),
+    );
   }
   if (router.scheduler) {
     parts.push('scheduler');
   }
   return parts.length > 0 ? parts.join(', ') : 'default';
+}
+
+/**
+ * Summarize the scaling configuration as a short human-readable string,
+ * for example "min=1, max=4, autoscaler=KEDA". Returns an empty string
+ * when the specification does not configure scaling.
+ */
+export function summarizeScaling(spec?: LLMInferenceServiceSpec): string {
+  const scaling = spec?.scaling;
+  if (!scaling) {
+    return '';
+  }
+
+  const parts: string[] = [];
+  if (scaling.minReplicas !== undefined) {
+    parts.push(`min=${scaling.minReplicas}`);
+  }
+  if (scaling.maxReplicas !== undefined) {
+    parts.push(`max=${scaling.maxReplicas}`);
+  }
+  if (scaling.wva) {
+    parts.push('autoscaler=workload variant autoscaler');
+  }
+  if (scaling.keda) {
+    parts.push('autoscaler=KEDA');
+  }
+  return parts.join(', ');
 }
 
 /**

--- a/frontend/src/app/shared/llm-inference-service.utils.ts
+++ b/frontend/src/app/shared/llm-inference-service.utils.ts
@@ -1,0 +1,199 @@
+import { Condition, Status, STATUS_TYPE } from 'kubeflow';
+import {
+  LLMInferenceServiceK8s,
+  LLMInferenceServiceSpec,
+} from '../types/kfserving/llm-inference-service';
+
+/*
+ * Pure parsing helpers for LLMInferenceService objects.
+ *
+ * Every function tolerates missing fields, because the backend serves
+ * whichever API version the cluster supports and a specification may
+ * delegate almost everything to the controller presets.
+ */
+
+export type LLMInferenceServiceTopology =
+  | 'Single node'
+  | 'Multi-node'
+  | 'Disaggregated'
+  | 'Disaggregated multi-node';
+
+/**
+ * Derive the requested serving topology from the workload blocks.
+ *
+ * The `worker` block requests multi-node orchestration and the `prefill`
+ * block requests disaggregated prefill and decode workloads. An absent
+ * block simply means the controller default, so a specification without
+ * any workload block is a single-node deployment.
+ */
+export function deriveTopology(
+  spec?: LLMInferenceServiceSpec,
+): LLMInferenceServiceTopology {
+  const hasWorker = !!spec?.worker;
+  const hasPrefill = !!spec?.prefill;
+
+  if (hasWorker && hasPrefill) {
+    return 'Disaggregated multi-node';
+  }
+  if (hasWorker) {
+    return 'Multi-node';
+  }
+  if (hasPrefill) {
+    return 'Disaggregated';
+  }
+  return 'Single node';
+}
+
+/**
+ * Summarize the parallelism configuration as a short human-readable string,
+ * for example "tensor=2, data=4". Returns an empty string when the
+ * specification does not configure parallelism.
+ */
+export function summarizeParallelism(spec?: LLMInferenceServiceSpec): string {
+  const parallelism = spec?.parallelism;
+  if (!parallelism) {
+    return '';
+  }
+
+  const parts: string[] = [];
+  if (parallelism.tensor !== undefined) {
+    parts.push(`tensor=${parallelism.tensor}`);
+  }
+  if (parallelism.data !== undefined) {
+    parts.push(`data=${parallelism.data}`);
+  }
+  if (parallelism.dataLocal !== undefined) {
+    parts.push(`data-local=${parallelism.dataLocal}`);
+  }
+  if (parallelism.pipeline !== undefined) {
+    parts.push(`pipeline=${parallelism.pipeline}`);
+  }
+  if (parallelism.expert) {
+    parts.push('expert');
+  }
+  return parts.join(', ');
+}
+
+/**
+ * Summarize which router components the specification requests, for
+ * example "gateway, route, scheduler". Returns "default" when the
+ * specification leaves routing entirely to the controller presets.
+ */
+export function summarizeRouter(spec?: LLMInferenceServiceSpec): string {
+  const router = spec?.router;
+  if (!router) {
+    return 'default';
+  }
+
+  const parts: string[] = [];
+  if (router.gateway) {
+    parts.push('gateway');
+  }
+  if (router.route) {
+    parts.push('route');
+  }
+  if (router.scheduler) {
+    parts.push('scheduler');
+  }
+  return parts.length > 0 ? parts.join(', ') : 'default';
+}
+
+/**
+ * Return the condition with the given type, or null when the object has
+ * no such condition yet. A freshly created object may briefly have no
+ * status at all.
+ */
+export function findCondition(
+  llmInferenceService: LLMInferenceServiceK8s,
+  conditionType: string,
+): Condition | null {
+  const conditions = llmInferenceService?.status?.conditions || [];
+  return conditions.find(condition => condition.type === conditionType) || null;
+}
+
+/**
+ * Return the base configuration names the specification references,
+ * in their declaration order.
+ */
+export function baseConfigurationNames(
+  spec?: LLMInferenceServiceSpec,
+): string[] {
+  return (spec?.baseRefs || []).map(reference => reference.name);
+}
+
+/**
+ * Return the names of the configurations the controller reports as applied.
+ *
+ * The appliedConfigs entries are not documented in the custom resource
+ * schema, so both plausible shapes are accepted: a plain name field and a
+ * full object with metadata.
+ */
+export function appliedConfigurationNames(
+  llmInferenceService: LLMInferenceServiceK8s,
+): string[] {
+  const appliedConfigurations =
+    llmInferenceService?.status?.appliedConfigs || [];
+  return appliedConfigurations
+    .map(
+      configuration =>
+        configuration?.name || configuration?.metadata?.name || '',
+    )
+    .filter(name => name !== '');
+}
+
+/**
+ * Derive the user-interface status from the object state.
+ *
+ * The shared getK8sObjectUiStatus helper orders conditions with an
+ * InferenceService-specific table, so this resource needs its own explicit
+ * ladder: terminating objects first, then readiness, then the first failed
+ * condition with a message, because that message is what a debugging user
+ * needs to read.
+ */
+export function getLLMInferenceServiceStatus(
+  llmInferenceService: LLMInferenceServiceK8s,
+): Status {
+  if (llmInferenceService?.metadata?.deletionTimestamp) {
+    return {
+      phase: STATUS_TYPE.TERMINATING,
+      state: '',
+      message: 'LLMInferenceService is being deleted.',
+    };
+  }
+
+  const conditions = llmInferenceService?.status?.conditions || [];
+  if (conditions.length === 0) {
+    return {
+      phase: STATUS_TYPE.WARNING,
+      state: '',
+      message:
+        'No status reported yet. Please take a look at the Events emitted for this LLMInferenceService.',
+    };
+  }
+
+  const ready = findCondition(llmInferenceService, 'Ready');
+  if (ready?.status === 'True') {
+    return {
+      phase: STATUS_TYPE.READY,
+      state: '',
+      message: 'LLMInferenceService is Ready.',
+    };
+  }
+
+  const failed = conditions.find(
+    condition => condition.status === 'False' && !!condition.message,
+  );
+  if (failed) {
+    return {
+      phase: STATUS_TYPE.WARNING,
+      state: '',
+      message: `${failed.reason}: ${failed.message}`,
+    };
+  }
+
+  return {
+    phase: STATUS_TYPE.WAITING,
+    state: '',
+    message: ready?.reason || 'LLMInferenceService is not ready yet.',
+  };
+}

--- a/frontend/src/app/shared/llm-inference-service.utils.ts
+++ b/frontend/src/app/shared/llm-inference-service.utils.ts
@@ -1,7 +1,11 @@
 import { Condition, Status, STATUS_TYPE } from 'kubeflow';
 import {
+  LLMInferenceServiceAddress,
   LLMInferenceServiceK8s,
   LLMInferenceServiceSpec,
+  LLMInferenceServiceStatus,
+  LLMInferenceServiceWorkload,
+  LLMInferenceServiceWorkloads,
 } from '../types/kfserving/llm-inference-service';
 
 /*
@@ -16,21 +20,55 @@ export type LLMInferenceServiceTopology =
   | 'Single node'
   | 'Multi-node'
   | 'Disaggregated'
-  | 'Disaggregated multi-node';
+  | 'Disaggregated multi-node'
+  | 'From configuration';
+
+export interface LLMInferenceServiceEndpoint {
+  url: string;
+  name?: string;
+}
 
 /**
- * Derive the requested serving topology from the workload blocks.
+ * Derive the serving topology from the object, preferring an explicit
+ * local workload, then the controller's observed workloads, and only
+ * then the controller default.
  *
- * The `worker` block requests multi-node orchestration and the `prefill`
- * block requests disaggregated prefill and decode workloads. An absent
- * block simply means the controller default, so a specification without
- * any workload block is a single-node deployment.
+ * An omitted local `worker`/`prefill` block is not enough to call the
+ * service single-node: `baseRefs` can inject those fields during
+ * configuration merge. Until workloads are observed, a referenced
+ * configuration is reported as inherited rather than guessed.
  */
 export function deriveTopology(
-  spec?: LLMInferenceServiceSpec,
+  llmInferenceService?: LLMInferenceServiceK8s,
 ): LLMInferenceServiceTopology {
-  const hasWorker = !!spec?.worker;
-  const hasPrefill = !!spec?.prefill;
+  const fromSpec = topologyFromSpec(llmInferenceService?.spec);
+  if (fromSpec) {
+    return fromSpec;
+  }
+
+  const fromWorkloads = topologyFromWorkloads(
+    llmInferenceService?.status?.workloads,
+  );
+  if (fromWorkloads) {
+    return fromWorkloads;
+  }
+
+  if ((llmInferenceService?.spec?.baseRefs || []).length > 0) {
+    return 'From configuration';
+  }
+
+  return 'Single node';
+}
+
+function topologyFromSpec(
+  spec?: LLMInferenceServiceSpec,
+): LLMInferenceServiceTopology | '' {
+  if (!spec) {
+    return '';
+  }
+
+  const hasPrefill = !!spec.prefill;
+  const hasWorker = !!spec.worker || !!spec.prefill?.worker;
 
   if (hasWorker && hasPrefill) {
     return 'Disaggregated multi-node';
@@ -41,16 +79,46 @@ export function deriveTopology(
   if (hasPrefill) {
     return 'Disaggregated';
   }
-  return 'Single node';
+  return '';
+}
+
+function topologyFromWorkloads(
+  workloads?: LLMInferenceServiceWorkloads,
+): LLMInferenceServiceTopology | '' {
+  if (!workloads) {
+    return '';
+  }
+
+  const hasPrefill = !!workloads.prefill;
+  const hasWorker = workloads.primary?.kind === 'LeaderWorkerSet';
+
+  if (hasWorker && hasPrefill) {
+    return 'Disaggregated multi-node';
+  }
+  if (hasWorker) {
+    return 'Multi-node';
+  }
+  if (hasPrefill) {
+    return 'Disaggregated';
+  }
+  if (workloads.primary) {
+    return 'Single node';
+  }
+  return '';
 }
 
 /**
  * Summarize the parallelism configuration as a short human-readable string,
  * for example "tensor=2, data=4". Returns an empty string when the
  * specification does not configure parallelism.
+ *
+ * Accepts either the top-level specification (decode) or a nested
+ * prefill workload, because both carry the same parallelism fields.
  */
-export function summarizeParallelism(spec?: LLMInferenceServiceSpec): string {
-  const parallelism = spec?.parallelism;
+export function summarizeParallelism(
+  source?: LLMInferenceServiceSpec | LLMInferenceServiceWorkload,
+): string {
+  const parallelism = source?.parallelism;
   if (!parallelism) {
     return '';
   }
@@ -124,9 +192,14 @@ export function summarizeRouter(spec?: LLMInferenceServiceSpec): string {
  * Summarize the scaling configuration as a short human-readable string,
  * for example "min=1, max=4, autoscaler=KEDA". Returns an empty string
  * when the specification does not configure scaling.
+ *
+ * Accepts either the top-level specification (decode) or a nested
+ * prefill workload, because both carry the same scaling fields.
  */
-export function summarizeScaling(spec?: LLMInferenceServiceSpec): string {
-  const scaling = spec?.scaling;
+export function summarizeScaling(
+  source?: LLMInferenceServiceSpec | LLMInferenceServiceWorkload,
+): string {
+  const scaling = source?.scaling;
   if (!scaling) {
     return '';
   }
@@ -145,6 +218,36 @@ export function summarizeScaling(spec?: LLMInferenceServiceSpec): string {
     parts.push('autoscaler=KEDA');
   }
   return parts.join(', ');
+}
+
+/**
+ * Collect the unique service URLs the object reports, primary `url`
+ * first, then `address` and `addresses`. Duplicates are dropped so the
+ * details page can render every reachable endpoint without repeating
+ * the primary URL.
+ */
+export function uniqueServiceUrls(
+  status?: LLMInferenceServiceStatus,
+): LLMInferenceServiceEndpoint[] {
+  const seen = new Set<string>();
+  const endpoints: LLMInferenceServiceEndpoint[] = [];
+
+  const add = (address?: LLMInferenceServiceAddress | string) => {
+    const url = typeof address === 'string' ? address : address?.url;
+    if (!url || seen.has(url)) {
+      return;
+    }
+    seen.add(url);
+    const name = typeof address === 'string' ? undefined : address?.name;
+    endpoints.push(name ? { url, name } : { url });
+  };
+
+  add(status?.url);
+  add(status?.address);
+  for (const address of status?.addresses || []) {
+    add(address);
+  }
+  return endpoints;
 }
 
 /**
@@ -236,7 +339,9 @@ export function getLLMInferenceServiceStatus(
     return {
       phase: STATUS_TYPE.WARNING,
       state: '',
-      message: `${failed.reason}: ${failed.message}`,
+      message: failed.reason
+        ? `${failed.reason}: ${failed.message}`
+        : failed.message,
     };
   }
 

--- a/frontend/src/app/types/backend.ts
+++ b/frontend/src/app/types/backend.ts
@@ -2,12 +2,15 @@ import { BackendResponse, Status, STATUS_TYPE, K8sObject } from 'kubeflow';
 import { EventObject } from './event';
 import { InferenceServiceK8s } from './kfserving/v1beta1';
 import { InferenceGraphK8s } from './kfserving/v1alpha1';
+import { LLMInferenceServiceK8s } from './kfserving/llm-inference-service';
 
 export interface MWABackendResponse extends BackendResponse {
   inferenceServices?: InferenceServiceK8s[];
   inferenceService?: InferenceServiceK8s;
   inferenceGraphs?: InferenceGraphK8s[];
   inferenceGraph?: InferenceGraphK8s;
+  llmInferenceServices?: LLMInferenceServiceK8s[];
+  llmInferenceService?: LLMInferenceServiceK8s;
   createdResources?: KServeResourceIdentity[];
   failedDocumentIndex?: number;
   failedResource?: KServeResourceIdentity;

--- a/frontend/src/app/types/kfserving/llm-inference-service.ts
+++ b/frontend/src/app/types/kfserving/llm-inference-service.ts
@@ -26,10 +26,45 @@ export interface LLMInferenceServiceParallelism {
   expert?: boolean;
 }
 
+/*
+ * The router components share one convention in both API versions: an empty
+ * object requests a controller-managed resource, while a `refs` list points
+ * at existing resources the user brings and manages themselves.
+ */
+export interface LLMInferenceServiceObjectReference {
+  name?: string;
+  namespace?: string;
+  kind?: string;
+  group?: string;
+}
+
+export interface LLMInferenceServiceHTTPRoute {
+  refs?: LLMInferenceServiceObjectReference[];
+  spec?: K8sObject;
+}
+
+export interface LLMInferenceServiceGatewayRoutes {
+  http?: LLMInferenceServiceHTTPRoute;
+  group?: string;
+  weight?: number;
+}
+
+export interface LLMInferenceServiceRouterReferences {
+  refs?: LLMInferenceServiceObjectReference[];
+}
+
 export interface LLMInferenceServiceRouter {
-  gateway?: K8sObject;
-  route?: K8sObject;
+  gateway?: LLMInferenceServiceRouterReferences;
+  route?: LLMInferenceServiceGatewayRoutes;
+  ingress?: LLMInferenceServiceRouterReferences;
   scheduler?: K8sObject;
+}
+
+export interface LLMInferenceServiceScaling {
+  minReplicas?: number;
+  maxReplicas?: number;
+  wva?: K8sObject;
+  keda?: K8sObject;
 }
 
 export interface LLMInferenceServiceBaseReference {
@@ -45,7 +80,7 @@ export interface LLMInferenceServiceSpec {
   template?: K8sObject;
   worker?: K8sObject;
   prefill?: K8sObject;
-  scaling?: K8sObject;
+  scaling?: LLMInferenceServiceScaling;
   storageInitializer?: K8sObject;
   annotations?: { [key: string]: string };
   labels?: { [key: string]: string };

--- a/frontend/src/app/types/kfserving/llm-inference-service.ts
+++ b/frontend/src/app/types/kfserving/llm-inference-service.ts
@@ -7,8 +7,8 @@ import { V1ObjectMeta } from '@kubernetes/client-node';
  * The backend serves whichever API version the cluster supports (v1alpha2
  * preferred, v1alpha1 as fallback), so every field that may differ between
  * the versions is optional and the parsing utilities handle absence
- * explicitly. Fields the pages only test for presence, such as the workload
- * templates, are deliberately typed loosely.
+ * explicitly. Workload templates stay loosely typed because the pages
+ * only test those blocks for presence.
  */
 
 export interface LLMInferenceServiceModel {
@@ -67,6 +67,19 @@ export interface LLMInferenceServiceScaling {
   keda?: K8sObject;
 }
 
+/*
+ * Decode uses the top-level replicas, template, worker, parallelism, and
+ * scaling fields. Prefill is the same shape nested under spec.prefill, so
+ * a disaggregated service can request independent prefill settings.
+ */
+export interface LLMInferenceServiceWorkload {
+  replicas?: number;
+  template?: K8sObject;
+  worker?: K8sObject;
+  parallelism?: LLMInferenceServiceParallelism;
+  scaling?: LLMInferenceServiceScaling;
+}
+
 export interface LLMInferenceServiceBaseReference {
   name: string;
 }
@@ -79,7 +92,7 @@ export interface LLMInferenceServiceSpec {
   router?: LLMInferenceServiceRouter;
   template?: K8sObject;
   worker?: K8sObject;
-  prefill?: K8sObject;
+  prefill?: LLMInferenceServiceWorkload;
   scaling?: LLMInferenceServiceScaling;
   storageInitializer?: K8sObject;
   annotations?: { [key: string]: string };
@@ -95,14 +108,32 @@ export interface LLMInferenceServiceAppliedConfiguration extends K8sObject {
   name?: string;
 }
 
+export interface LLMInferenceServiceAddress {
+  name?: string;
+  url?: string;
+}
+
+export interface LLMInferenceServiceWorkloadReference {
+  apiGroup?: string;
+  kind?: string;
+  name?: string;
+}
+
+export interface LLMInferenceServiceWorkloads {
+  primary?: LLMInferenceServiceWorkloadReference;
+  prefill?: LLMInferenceServiceWorkloadReference;
+  service?: LLMInferenceServiceWorkloadReference;
+  scheduler?: LLMInferenceServiceWorkloadReference;
+}
+
 export interface LLMInferenceServiceStatus {
   conditions?: Condition[];
   url?: string;
-  address?: K8sObject;
-  addresses?: K8sObject[];
+  address?: LLMInferenceServiceAddress;
+  addresses?: LLMInferenceServiceAddress[];
   appliedConfigs?: LLMInferenceServiceAppliedConfiguration[];
   router?: K8sObject;
-  workloads?: K8sObject;
+  workloads?: LLMInferenceServiceWorkloads;
   observedGeneration?: number;
 }
 

--- a/frontend/src/app/types/kfserving/llm-inference-service.ts
+++ b/frontend/src/app/types/kfserving/llm-inference-service.ts
@@ -1,0 +1,97 @@
+import { Condition, K8sObject, Status } from 'kubeflow';
+import { V1ObjectMeta } from '@kubernetes/client-node';
+
+/*
+ * Version-tolerant types for the LLMInferenceService custom resource.
+ *
+ * The backend serves whichever API version the cluster supports (v1alpha2
+ * preferred, v1alpha1 as fallback), so every field that may differ between
+ * the versions is optional and the parsing utilities handle absence
+ * explicitly. Fields the pages only test for presence, such as the workload
+ * templates, are deliberately typed loosely.
+ */
+
+export interface LLMInferenceServiceModel {
+  uri: string;
+  name?: string;
+  lora?: K8sObject;
+}
+
+export interface LLMInferenceServiceParallelism {
+  tensor?: number;
+  data?: number;
+  dataLocal?: number;
+  dataRPCPort?: number;
+  pipeline?: number;
+  expert?: boolean;
+}
+
+export interface LLMInferenceServiceRouter {
+  gateway?: K8sObject;
+  route?: K8sObject;
+  scheduler?: K8sObject;
+}
+
+export interface LLMInferenceServiceBaseReference {
+  name: string;
+}
+
+export interface LLMInferenceServiceSpec {
+  model: LLMInferenceServiceModel;
+  baseRefs?: LLMInferenceServiceBaseReference[];
+  replicas?: number;
+  parallelism?: LLMInferenceServiceParallelism;
+  router?: LLMInferenceServiceRouter;
+  template?: K8sObject;
+  worker?: K8sObject;
+  prefill?: K8sObject;
+  scaling?: K8sObject;
+  storageInitializer?: K8sObject;
+  annotations?: { [key: string]: string };
+  labels?: { [key: string]: string };
+}
+
+/*
+ * The applied configuration entries are not documented in the custom
+ * resource schema, so both plausible shapes are modeled: a plain name
+ * field and a full object with metadata.
+ */
+export interface LLMInferenceServiceAppliedConfiguration extends K8sObject {
+  name?: string;
+}
+
+export interface LLMInferenceServiceStatus {
+  conditions?: Condition[];
+  url?: string;
+  address?: K8sObject;
+  addresses?: K8sObject[];
+  appliedConfigs?: LLMInferenceServiceAppliedConfiguration[];
+  router?: K8sObject;
+  workloads?: K8sObject;
+  observedGeneration?: number;
+}
+
+export interface LLMInferenceServiceK8s extends K8sObject {
+  metadata?: V1ObjectMeta;
+  spec?: LLMInferenceServiceSpec;
+  status?: LLMInferenceServiceStatus;
+}
+
+/*
+ * The internal representation the list page renders. The page computes the
+ * `ui` block once per polling response, so the table only ever reads
+ * precomputed properties during change detection.
+ */
+export interface LLMInferenceServiceIR extends LLMInferenceServiceK8s {
+  ui?: {
+    status?: Status;
+    topology?: string;
+    parallelism?: string;
+    router?: string;
+    modelName?: string;
+    link?: {
+      text: string;
+      url: string;
+    };
+  };
+}

--- a/manifests/kustomize/base/cluster-role.yaml
+++ b/manifests/kustomize/base/cluster-role.yaml
@@ -45,6 +45,15 @@ rules:
   - patch
   - update
 - apiGroups:
+  - serving.kserve.io
+  resources:
+  - llminferenceservices
+  - llminferenceservices/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - serving.knative.dev
   resources:
   - services


### PR DESCRIPTION
Implements kserve/models-web-app#175. The web application could already display InferenceService and InferenceGraph custom resources but had no visibility into LLMInferenceService, forcing anyone deploying a large language model to fall back to kubectl for basic questions such as whether the resource was accepted, how far the controller had progressed, and what topology and parallelism the specification actually requested. This change is scoped to reading; the create, edit and delete workflows are follow ups.

Assisted-By: Claude <noreply@anthropic.com>